### PR TITLE
Split the create namespace into 2 classes

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controllers/AdminController.java
+++ b/src/main/java/com/michelin/ns4kafka/controllers/AdminController.java
@@ -1,5 +1,14 @@
 package com.michelin.ns4kafka.controllers;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+
 import com.michelin.ns4kafka.models.AccessControlEntry;
 import com.michelin.ns4kafka.models.Namespace;
 import com.michelin.ns4kafka.models.RoleBinding;
@@ -7,26 +16,22 @@ import com.michelin.ns4kafka.repositories.AccessControlEntryRepository;
 import com.michelin.ns4kafka.repositories.NamespaceRepository;
 import com.michelin.ns4kafka.repositories.RoleBindingRepository;
 import com.michelin.ns4kafka.security.RessourceBasedSecurityRule;
-import com.michelin.ns4kafka.services.KafkaAsyncExecutorConfig;
+import com.michelin.ns4kafka.services.NewNamespaceValidator;
 import com.michelin.ns4kafka.validation.ConnectValidator;
-import com.michelin.ns4kafka.validation.ResourceValidationException;
 import com.michelin.ns4kafka.validation.TopicValidator;
+
+import org.slf4j.LoggerFactory;
+
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.http.HttpStatus;
-import io.micronaut.http.annotation.*;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.Status;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.security.RolesAllowed;
-import javax.inject.Inject;
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @RolesAllowed(RessourceBasedSecurityRule.IS_ADMIN)
 @Controller("/api/admin")
@@ -34,29 +39,32 @@ public class AdminController {
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(AdminController.class);
 
     @Inject
+    NewNamespaceValidator newNamespaceValidator;
+    @Inject
     NamespaceRepository namespaceRepository;
     @Inject
     AccessControlEntryRepository accessControlEntryRepository;
     @Inject
     RoleBindingRepository roleBindingRepository;
-    @Inject
-    List<KafkaAsyncExecutorConfig> kafkaAsyncExecutorConfigList;
 
     @Delete("/acl/{acl}")
     @Status(HttpStatus.NO_CONTENT)
-    public void deleteACL(String acl){
+    public void deleteACL(String acl) {
         accessControlEntryRepository.deleteByName(acl);
     }
-    @Delete("/namespace/{namespace}")
-    public List<Object> deleteNamespace(String namespace){
-        Optional<Namespace> namespaceOptional = namespaceRepository.findByName(namespace);
-        if(namespaceOptional.isPresent()){
 
-            List<AccessControlEntry> accessControlEntryList = accessControlEntryRepository.findAllGrantedToNamespace(namespace);
+    @Delete("/namespace/{namespace}")
+    public List<Object> deleteNamespace(String namespace) {
+        Optional<Namespace> namespaceOptional = namespaceRepository.findByName(namespace);
+        if (namespaceOptional.isPresent()) {
+
+            List<AccessControlEntry> accessControlEntryList = accessControlEntryRepository
+                    .findAllGrantedToNamespace(namespace);
             List<RoleBinding> roleBindingList = roleBindingRepository.findAllForNamespace(namespace);
 
             namespaceRepository.delete(namespaceOptional.get());
-            accessControlEntryList.forEach(accessControlEntry -> accessControlEntryRepository.deleteByName(accessControlEntry.getMetadata().getName()));
+            accessControlEntryList.forEach(accessControlEntry -> accessControlEntryRepository
+                    .deleteByName(accessControlEntry.getMetadata().getName()));
             roleBindingList.forEach(roleBinding -> roleBindingRepository.delete(roleBinding));
 
             List<Object> returnList = new ArrayList<>();
@@ -69,76 +77,37 @@ public class AdminController {
     }
 
     @Post("/namespace")
-    public Namespace createNamespace(@Valid @Body NamespaceCreationRequest namespaceCreationRequest){
+    public Namespace createNamespace(@Valid @Body NamespaceCreationRequest namespaceCreationRequest) {
 
-        // Validation steps:
-        // - namespace must not already exist
-        // - cluster must exist
-        // - kafkaUser must not exist within the namespaces linked to this cluster
-        // - prefix ? prefix overlap ? "seb" currently exists and we try to create "se" or "seb_a"
-        //      current     new     check
-        //      seb         seb_a   new.startswith(current)
-        //      seb         se      current.startswith(new)
-        List<String> validationErrors = new ArrayList<>();
-        if(namespaceRepository.findByName(namespaceCreationRequest.getName()).isPresent()) {
-            validationErrors.add("Namespace already exist");
+        if (!newNamespaceValidator.validate(namespaceCreationRequest)) {
         }
-
-        if(kafkaAsyncExecutorConfigList.stream()
-                .noneMatch(config -> config.getName().equals(namespaceCreationRequest.getCluster()))) {
-            validationErrors.add("Cluster doesn't exist");
-        }
-        if(namespaceRepository.findAllForCluster(namespaceCreationRequest.getCluster()).stream()
-                .anyMatch(namespace -> namespace.getDefaulKafkatUser().equals(namespaceCreationRequest.getKafkaUser()))){
-            validationErrors.add("KafkaUser already exist");
-        }
-        List<AccessControlEntry> prefixInUse = accessControlEntryRepository.findAllForCluster(namespaceCreationRequest.getCluster()).stream()
-                .filter(ace -> ace.getSpec().getResourcePatternType() == AccessControlEntry.ResourcePatternType.PREFIXED)
-                .filter(ace -> ace.getSpec().getResourceType() == AccessControlEntry.ResourceType.TOPIC)
-                .filter(ace -> ace.getSpec().getResource().startsWith(namespaceCreationRequest.getPrefix())
-                        || namespaceCreationRequest.getPrefix().startsWith(ace.getSpec().getResource()))
-            .collect(Collectors.toList());
-        if(prefixInUse.size()>0) {
-            validationErrors.add(String.format("Prefix overlaps with namespace %s: [%s]"
-                    , prefixInUse.get(0).getSpec().getGrantedTo()
-                    , prefixInUse.get(0).getSpec().getResource()));
-        }
-
-
-        if(validationErrors.size()>0){
-            throw new ResourceValidationException(validationErrors);
-        }
-        //Prepare Namespace
-        Namespace toCreate = Namespace.builder()
-                .name(namespaceCreationRequest.getName())
+        // Prepare Namespace
+        Namespace toCreate = Namespace.builder().name(namespaceCreationRequest.getName())
                 .cluster(namespaceCreationRequest.getCluster())
-                .defaulKafkatUser(namespaceCreationRequest.getKafkaUser())
-                .topicValidator(TopicValidator.makeDefault())
-                .connectValidator(ConnectValidator.makeDefault())
-                .build();
+                .defaulKafkatUser(namespaceCreationRequest.getKafkaUser()).topicValidator(TopicValidator.makeDefault())
+                .connectValidator(ConnectValidator.makeDefault()).build();
         // Prepare ACLs
         List<AccessControlEntry> accessControlEntryList = AccessControlEntry.buildGeneric(
-                namespaceCreationRequest.getName(),
-                namespaceCreationRequest.getCluster(),
+                namespaceCreationRequest.getName(), namespaceCreationRequest.getCluster(),
                 namespaceCreationRequest.getPrefix());
 
-        //Store Namespace and ACLs;
+        // Store Namespace and ACLs;
         Namespace created = namespaceRepository.createNamespace(toCreate);
-        roleBindingRepository.create(new RoleBinding(namespaceCreationRequest.getName(),namespaceCreationRequest.getGroup()));
+        roleBindingRepository
+                .create(new RoleBinding(namespaceCreationRequest.getName(), namespaceCreationRequest.getGroup()));
         accessControlEntryList.forEach(accessControlEntry -> {
             LOG.info(accessControlEntry.getSpec().toString());
             accessControlEntryRepository.create(accessControlEntry);
 
         });
-        return  created;
+        return created;
     }
-
 
     @Introspected
     @Getter
     @Setter
     @NoArgsConstructor
-    public static class NamespaceCreationRequest{
+    public static class NamespaceCreationRequest {
         @NotBlank
         String name;
         @NotBlank

--- a/src/main/java/com/michelin/ns4kafka/services/NewNamespaceValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/services/NewNamespaceValidator.java
@@ -1,0 +1,68 @@
+package com.michelin.ns4kafka.services;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.michelin.ns4kafka.controllers.AdminController.NamespaceCreationRequest;
+import com.michelin.ns4kafka.models.AccessControlEntry;
+import com.michelin.ns4kafka.repositories.AccessControlEntryRepository;
+import com.michelin.ns4kafka.repositories.NamespaceRepository;
+import com.michelin.ns4kafka.validation.ResourceValidationException;
+
+@Singleton
+public class NewNamespaceValidator {
+
+    @Inject
+    NamespaceRepository namespaceRepository;
+    @Inject
+    List<KafkaAsyncExecutorConfig> kafkaAsyncExecutorConfigList;
+    @Inject
+    AccessControlEntryRepository accessControlEntryRepository;
+
+    public boolean validate(NamespaceCreationRequest namespaceCreationRequest) {
+
+        // Validation steps:
+        // - namespace must not already exist
+        // - cluster must exist
+        // - kafkaUser must not exist within the namespaces linked to this cluster
+        // - prefix ? prefix overlap ? "seb" currently exists and we try to create "se"
+        // or "seb_a"
+        // current new check
+        // seb seb_a new.startswith(current)
+        // seb se current.startswith(new)
+        List<String> validationErrors = new ArrayList<>();
+        if (namespaceRepository.findByName(namespaceCreationRequest.getName()).isPresent()) {
+            validationErrors.add("Namespace already exist");
+        }
+
+        if (kafkaAsyncExecutorConfigList.stream()
+                .noneMatch(config -> config.getName().equals(namespaceCreationRequest.getCluster()))) {
+            validationErrors.add("Cluster doesn't exist");
+        }
+        if (namespaceRepository.findAllForCluster(namespaceCreationRequest.getCluster()).stream().anyMatch(
+                namespace -> namespace.getDefaulKafkatUser().equals(namespaceCreationRequest.getKafkaUser()))) {
+            validationErrors.add("KafkaUser already exist");
+        }
+        List<AccessControlEntry> prefixInUse = accessControlEntryRepository
+                .findAllForCluster(namespaceCreationRequest.getCluster()).stream()
+                .filter(ace -> ace.getSpec()
+                        .getResourcePatternType() == AccessControlEntry.ResourcePatternType.PREFIXED)
+                .filter(ace -> ace.getSpec().getResourceType() == AccessControlEntry.ResourceType.TOPIC)
+                .filter(ace -> ace.getSpec().getResource().startsWith(namespaceCreationRequest.getPrefix())
+                        || namespaceCreationRequest.getPrefix().startsWith(ace.getSpec().getResource()))
+                .collect(Collectors.toList());
+        if (prefixInUse.size() > 0) {
+            validationErrors.add(String.format("Prefix overlaps with namespace %s: [%s]",
+                    prefixInUse.get(0).getSpec().getGrantedTo(), prefixInUse.get(0).getSpec().getResource()));
+        }
+
+        if (validationErrors.size() > 0) {
+            throw new ResourceValidationException(validationErrors);
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
The verification of the namespaceCreationRequest is in a new services dedicated.
The Admin controller class now only add or remove from the repositories.