### PR TITLE
Fixed bug with RoleBinding allows /api/namespaces/ns/role-bindings

### DIFF
--- a/api/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
+++ b/api/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
@@ -28,7 +28,7 @@ public class ResourceBasedSecurityRule implements SecurityRule {
 
     public static final String IS_ADMIN = "isAdmin()";
 
-    private final Pattern namespacedResourcePattern = Pattern.compile("^\\/api\\/namespaces\\/(?<namespace>[a-zA-Z0-9_-]+)\\/(?<resourceType>[a-z]+)(\\/([a-zA-Z0-9_-]+)(\\/(?<resourceSubtype>[a-z]+))?)?");
+    private final Pattern namespacedResourcePattern = Pattern.compile("^\\/api\\/namespaces\\/(?<namespace>[a-zA-Z0-9_-]+)\\/(?<resourceType>[a-z_-]+)(\\/([a-zA-Z0-9_-]+)(\\/(?<resourceSubtype>[a-z]+))?)?");
 
 
     SecurityConfig securityConfig;

--- a/api/src/test/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRuleTest.java
+++ b/api/src/test/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRuleTest.java
@@ -149,6 +149,29 @@ public class ResourceBasedSecurityRuleTest {
         SecurityRuleResult actual = resourceBasedSecurityRule.check(HttpRequest.GET("/api/namespaces/test/connects/name/restart"),null, claims);
         Assertions.assertEquals(SecurityRuleResult.ALLOWED, actual);
     }
+    @Test
+    void CheckReturnsAllowed_ResourceWithHyphen(){
+        List<String> groups = List.of("group1");
+        Map<String,Object> claims = Map.of("sub","user", "groups", groups, "roles", List.of());
+        Mockito.when(roleBindingRepository.findAllForGroups(groups))
+                .thenReturn(List.of(RoleBinding.builder()
+                        .metadata(ObjectMeta.builder().namespace("test")
+                                .build())
+                        .spec(RoleBinding.RoleBindingSpec.builder()
+                                .role(RoleBinding.Role.builder()
+                                        .resourceTypes(List.of("role-bindings"))
+                                        .verbs(List.of(RoleBinding.Verb.GET))
+                                        .build())
+                                .subject(RoleBinding.Subject.builder().subjectName("group1")
+                                        .build())
+                                .build())
+                        .build()));
+        Mockito.when(namespaceRepository.findByName("test"))
+                .thenReturn(Optional.of(Namespace.builder().build()));
+
+        SecurityRuleResult actual = resourceBasedSecurityRule.check(HttpRequest.GET("/api/namespaces/test/role-bindings"),null, claims);
+        Assertions.assertEquals(SecurityRuleResult.ALLOWED, actual);
+    }
 
   @Test
     void CheckReturnsUnknown_SubResource(){


### PR DESCRIPTION
RoleBinding allowing access on /api/namespaces/ns/role-bindings failed to match because the ``-`` in ``role-bindings`` was not allowed in the regex