### PR TITLE
403 Forbidden when using controller methods with resource name containing . (dot)

### DIFF
--- a/api/src/main/java/com/michelin/ns4kafka/models/ObjectMeta.java
+++ b/api/src/main/java/com/michelin/ns4kafka/models/ObjectMeta.java
@@ -5,6 +5,7 @@ import io.micronaut.core.annotation.Introspected;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import java.util.Date;
 import java.util.Map;
 
@@ -15,6 +16,7 @@ import java.util.Map;
 @Data
 public class ObjectMeta {
     @NotBlank
+    @Pattern(regexp = "^[a-zA-Z0-9_.-]+$")
     private String name;
     private String namespace;
     private String cluster;

--- a/api/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
+++ b/api/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
@@ -27,7 +27,7 @@ public class ResourceBasedSecurityRule implements SecurityRule {
 
     public static final String IS_ADMIN = "isAdmin()";
 
-    private final Pattern namespacedResourcePattern = Pattern.compile("^\\/api\\/namespaces\\/(?<namespace>[a-zA-Z0-9_-]+)\\/(?<resourceType>[a-z_-]+)(\\/([a-zA-Z0-9_.-]+)(\\/(?<resourceSubtype>[a-z]+))?)?");
+    private final Pattern namespacedResourcePattern = Pattern.compile("^\\/api\\/namespaces\\/(?<namespace>[a-zA-Z0-9_-]+)\\/(?<resourceType>[a-z_-]+)(\\/([a-zA-Z0-9_.-]+)(\\/(?<resourceSubtype>[a-z]+))?)?$");
 
 
     SecurityConfig securityConfig;

--- a/api/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
+++ b/api/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
@@ -27,7 +27,7 @@ public class ResourceBasedSecurityRule implements SecurityRule {
 
     public static final String IS_ADMIN = "isAdmin()";
 
-    private final Pattern namespacedResourcePattern = Pattern.compile("^\\/api\\/namespaces\\/(?<namespace>[a-zA-Z0-9_-]+)\\/(?<resourceType>[a-z_-]+)(\\/([a-zA-Z0-9_-]+)(\\/(?<resourceSubtype>[a-z]+))?)?");
+    private final Pattern namespacedResourcePattern = Pattern.compile("^\\/api\\/namespaces\\/(?<namespace>[a-zA-Z0-9_-]+)\\/(?<resourceType>[a-z_-]+)(\\/([a-zA-Z0-9_.-]+)(\\/(?<resourceSubtype>[a-z]+))?)?");
 
 
     SecurityConfig securityConfig;


### PR DESCRIPTION
Any operation on subresource : 
- POST /api/namespaces/xxxxx/consumer-groups/`object-name`/reset

If `object-name` contained dot `.`
Those API calls would return 401 Forbidden

Fixed by : 
- adding `.` in the `namespacedResourcePattern` regex related to resource name
- adding `$` to the end of the `namespacedResourcePattern` regex
- adding Pattern annotation to the ObjectMeta name to prevent any other character

closes #85 