### PR TITLE
Added configurable columns display in CLI

### DIFF
--- a/api/src/main/java/com/michelin/ns4kafka/controllers/ApiResourcesController.java
+++ b/api/src/main/java/com/michelin/ns4kafka/controllers/ApiResourcesController.java
@@ -14,48 +14,50 @@ import java.util.List;
 @RolesAllowed(SecurityRule.IS_ANONYMOUS)
 @Controller("/api-resources")
 public class ApiResourcesController {
-
-    @Get
-    public List<ResourceDefinition> list() {
-        return List.of(
-                // TODO generate from Resource classes
-                // Namespaced Resources
-                ResourceDefinition.builder()
-                        .kind("AccessControlEntry")
-                        .namespaced(true)
-                        .synchronizable(false)
-                        .path("acls")
-                        .names(List.of("acls", "acl", "ac"))
-                        .build(),
-                ResourceDefinition.builder()
-                        .kind("Connector")
-                        .namespaced(true)
-                        .synchronizable(true)
-                        .path("connects")
-                        .names(List.of("connects", "connect", "co"))
-                        .build(),
-                ResourceDefinition.builder()
-                        .kind("RoleBinding")
-                        .namespaced(true)
-                        .synchronizable(false)
-                        .path("role-bindings")
-                        .names(List.of("rolebindings", "rolebinding", "rb"))
-                        .build(),
-                ResourceDefinition.builder()
-                        .kind("Topic")
-                        .namespaced(true)
-                        .synchronizable(true)
-                        .path("topics")
-                        .names(List.of("topics", "topic", "to"))
-                        .build(),
-                // Non-Namespaced Resources
-                ResourceDefinition.builder()
-                        .kind("Namespace")
+    public static final ResourceDefinition ACL = ResourceDefinition.builder()
+            .kind("AccessControlEntry")
+            .namespaced(true)
+            .synchronizable(false)
+            .path("acls")
+            .names(List.of("acls", "acl", "ac"))
+            .build();
+    public static final ResourceDefinition CONNECTOR = ResourceDefinition.builder()
+            .kind("Connector")
+            .namespaced(true)
+            .synchronizable(true)
+            .path("connects")
+            .names(List.of("connects", "connect", "co"))
+            .build();
+    public static final ResourceDefinition ROLE_BINDING = ResourceDefinition.builder()
+            .kind("RoleBinding")
+            .namespaced(true)
+            .synchronizable(false)
+            .path("role-bindings")
+            .names(List.of("rolebindings", "rolebinding", "rb"))
+            .build();
+    public static final ResourceDefinition TOPIC = ResourceDefinition.builder()
+            .kind("Topic")
+            .namespaced(true)
+            .synchronizable(true)
+            .path("topics")
+            .names(List.of("topics", "topic", "to"))
+            .build();
+    public static final ResourceDefinition NAMESPACE = ResourceDefinition.builder()
+            .kind("Namespace")
                         .namespaced(false)
                         .synchronizable(false)
                         .path("namespaces")
                         .names(List.of("namespaces", "namespace", "ns"))
-                        .build()
+            .build();
+
+    @Get
+    public List<ResourceDefinition> list() {
+        return List.of(
+                ACL,
+                CONNECTOR,
+                ROLE_BINDING,
+                TOPIC,
+                NAMESPACE
                 );
     }
 

--- a/cli/src/main/java/com/michelin/ns4kafka/cli/DeleteRecordsSubcommand.java
+++ b/cli/src/main/java/com/michelin/ns4kafka/cli/DeleteRecordsSubcommand.java
@@ -1,6 +1,7 @@
 package com.michelin.ns4kafka.cli;
 
 import com.michelin.ns4kafka.cli.models.Resource;
+import com.michelin.ns4kafka.cli.services.FormatService;
 import com.michelin.ns4kafka.cli.services.LoginService;
 import com.michelin.ns4kafka.cli.services.ResourceService;
 import picocli.CommandLine;
@@ -21,6 +22,8 @@ public class DeleteRecordsSubcommand implements Callable<Integer> {
     public LoginService loginService;
     @Inject
     public ResourceService resourceService;
+    @Inject
+    public FormatService formatService;
 
     @CommandLine.ParentCommand
     public KafkactlCommand kafkactlCommand;
@@ -46,7 +49,7 @@ public class DeleteRecordsSubcommand implements Callable<Integer> {
 
         Resource resource = resourceService.deleteRecords(namespace, topic, dryRun);
 
-        FormatUtils.displaySingle(null, resource, "yaml");
+        formatService.displaySingle(null, resource, "yaml");
 
         return 0;
     }

--- a/cli/src/main/java/com/michelin/ns4kafka/cli/GetSubcommand.java
+++ b/cli/src/main/java/com/michelin/ns4kafka/cli/GetSubcommand.java
@@ -5,6 +5,7 @@ import com.michelin.ns4kafka.cli.client.NamespacedResourceClient;
 import com.michelin.ns4kafka.cli.models.ApiResource;
 import com.michelin.ns4kafka.cli.models.Resource;
 import com.michelin.ns4kafka.cli.services.ApiResourcesService;
+import com.michelin.ns4kafka.cli.services.FormatService;
 import com.michelin.ns4kafka.cli.services.LoginService;
 import com.michelin.ns4kafka.cli.services.ResourceService;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
@@ -42,6 +43,8 @@ public class GetSubcommand implements Callable<Integer> {
     @Inject
     public ResourceService resourceService;
     @Inject
+    public FormatService formatService;
+    @Inject
     public KafkactlConfig kafkactlConfig;
 
     @CommandLine.ParentCommand
@@ -77,9 +80,9 @@ public class GetSubcommand implements Callable<Integer> {
                 // 4.a list all resources for given types (k get all, k get topics)
                 Map<ApiResource, List<Resource>> resources = resourceService.listAll(apiResources, namespace);
                 // 5.a display all resources by type
-                resources.forEach((k, v) -> FormatUtils.displayList(k, v, output));
+                resources.forEach((k, v) -> formatService.displayList(k, v, output));
             } catch (HttpClientResponseException e) {
-                FormatUtils.displayError(e, apiResources.get(0).getKind(), null);
+                formatService.displayError(e, apiResources.get(0).getKind(), null);
             } catch (Exception e) {
                 System.out.println("Error during get for resource type " + resourceType + ": " + e.getMessage());
             }
@@ -88,9 +91,9 @@ public class GetSubcommand implements Callable<Integer> {
             try {
                 // 4.b get individual resources for given types (k get topic topic1)
                 Resource singleResource = resourceService.getSingleResourceWithType(apiResources.get(0), namespace, resourceName.get(), true);
-                FormatUtils.displaySingle(apiResources.get(0), singleResource, output);
+                formatService.displaySingle(apiResources.get(0), singleResource, output);
             } catch (HttpClientResponseException e) {
-                FormatUtils.displayError(e, apiResources.get(0).getKind(), resourceName.get());
+                formatService.displayError(e, apiResources.get(0).getKind(), resourceName.get());
             } catch (Exception e) {
                 System.out.println("Error during get for resource type " + apiResources.get(0).getKind() + "/" + resourceName.get() + ": " + e.getMessage());
             }

--- a/cli/src/main/java/com/michelin/ns4kafka/cli/ImportSubcommand.java
+++ b/cli/src/main/java/com/michelin/ns4kafka/cli/ImportSubcommand.java
@@ -3,6 +3,7 @@ package com.michelin.ns4kafka.cli;
 import com.michelin.ns4kafka.cli.models.ApiResource;
 import com.michelin.ns4kafka.cli.models.Resource;
 import com.michelin.ns4kafka.cli.services.ApiResourcesService;
+import com.michelin.ns4kafka.cli.services.FormatService;
 import com.michelin.ns4kafka.cli.services.LoginService;
 import com.michelin.ns4kafka.cli.services.ResourceService;
 import picocli.CommandLine;
@@ -26,6 +27,8 @@ public class ImportSubcommand implements Callable<Integer> {
     public ResourceService resourceService;
     @Inject
     public ApiResourcesService apiResourcesService;
+    @Inject
+    public FormatService formatService;
     @Inject
     public KafkactlConfig kafkactlConfig;
 
@@ -58,7 +61,7 @@ public class ImportSubcommand implements Callable<Integer> {
         Map<ApiResource, List<Resource>> resources = resourceService.importAll(apiResources, namespace, dryRun);
 
         // 5.a display all resources by type
-        resources.forEach((k, v) -> FormatUtils.displayList(k, v, "table"));
+        resources.forEach((k, v) -> formatService.displayList(k, v, "table"));
         return 0;
 
     }

--- a/cli/src/main/java/com/michelin/ns4kafka/cli/KafkactlConfig.java
+++ b/cli/src/main/java/com/michelin/ns4kafka/cli/KafkactlConfig.java
@@ -1,8 +1,12 @@
 package com.michelin.ns4kafka.cli;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.convert.format.MapFormat;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.List;
+import java.util.Map;
 
 @ConfigurationProperties("kafkactl")
 @Getter
@@ -13,4 +17,6 @@ public class KafkactlConfig {
     public String api;
     public String userToken;
     public String currentNamespace;
+    @MapFormat(transformation = MapFormat.MapTransformation.FLAT)
+    public Map<String, List<String>> tableFormat;
 }

--- a/cli/src/main/java/com/michelin/ns4kafka/cli/ResetOffsetsSubcommand.java
+++ b/cli/src/main/java/com/michelin/ns4kafka/cli/ResetOffsetsSubcommand.java
@@ -2,6 +2,7 @@ package com.michelin.ns4kafka.cli;
 
 import com.michelin.ns4kafka.cli.models.ObjectMeta;
 import com.michelin.ns4kafka.cli.models.Resource;
+import com.michelin.ns4kafka.cli.services.FormatService;
 import com.michelin.ns4kafka.cli.services.LoginService;
 import com.michelin.ns4kafka.cli.services.ResourceService;
 import picocli.CommandLine;
@@ -24,6 +25,8 @@ public class ResetOffsetsSubcommand implements Callable<Integer> {
     public LoginService loginService;
     @Inject
     public ResourceService resourceService;
+    @Inject
+    public FormatService formatService;
 
     @Inject
     public KafkactlConfig kafkactlConfig;
@@ -110,7 +113,7 @@ public class ResetOffsetsSubcommand implements Callable<Integer> {
 
         Resource resource = resourceService.resetOffsets(namespace, group, consumerGroupResetOffset, dryRun);
         if (resource != null) {
-            FormatUtils.displaySingle(null, resource, "yaml");
+            formatService.displaySingle(null, resource, "yaml");
             return 0;
         }
 

--- a/cli/src/main/java/com/michelin/ns4kafka/cli/services/FormatService.java
+++ b/cli/src/main/java/com/michelin/ns4kafka/cli/services/FormatService.java
@@ -151,11 +151,11 @@ public class FormatService {
 
             public String transform(JsonNode node) {
                 String output = null;
-                String cell = node.at(this.jsonPointer).asText();
+                JsonNode cell = node.at(this.jsonPointer);
                 switch (this.transform) {
                     case "AGO":
                         try {
-                            Date d = Date.from(Instant.parse(cell));
+                            Date d = Date.from(Instant.parse(cell.asText()));
                             output = new PrettyTime().format(d);
                         } catch (DateTimeParseException e) {
                             output = "err:" + cell;
@@ -163,7 +163,7 @@ public class FormatService {
                         break;
                     case "PERIOD":
                         try {
-                            long ms = Long.parseLong(cell);
+                            long ms = Long.parseLong(cell.asText());
                             long days = TimeUnit.MILLISECONDS.toDays(ms);
                             long hours = TimeUnit.MILLISECONDS.toHours(ms - TimeUnit.DAYS.toMillis(days)) ;
                             long minutes = TimeUnit.MILLISECONDS.toMinutes(ms - TimeUnit.DAYS.toMillis(days) - TimeUnit.HOURS.toMillis(hours));
@@ -176,7 +176,13 @@ public class FormatService {
                         break;
                     case "NONE":
                     default:
-                        output = cell;
+                        if(cell.isArray()){
+                            List<String> childs = new ArrayList<>();
+                            cell.elements().forEachRemaining(jsonNode -> childs.add(jsonNode.asText()));
+                            output = "["+String.join(",", childs)+"]";
+                        } else {
+                            output = cell.asText();
+                        }
                         break;
                 }
                 // Check size for later

--- a/cli/src/main/java/com/michelin/ns4kafka/cli/services/FormatService.java
+++ b/cli/src/main/java/com/michelin/ns4kafka/cli/services/FormatService.java
@@ -112,14 +112,14 @@ public class FormatService {
 
         @Override
         public String toString() {
-            CommandLine.Help.Column[] columns = this.columns
+            CommandLine.Help.Column[] sizedColumns = this.columns
                     .stream()
                     .map(column -> new CommandLine.Help.Column(column.size, 2, CommandLine.Help.Column.Overflow.SPAN))
                     .toArray(CommandLine.Help.Column[]::new);
 
             CommandLine.Help.TextTable tt = CommandLine.Help.TextTable.forColumns(
                     CommandLine.Help.defaultColorScheme(CommandLine.Help.Ansi.AUTO),
-                    columns
+                    sizedColumns
             );
 
             // Create Header Row

--- a/cli/src/main/java/com/michelin/ns4kafka/cli/services/ResourceService.java
+++ b/cli/src/main/java/com/michelin/ns4kafka/cli/services/ResourceService.java
@@ -1,6 +1,5 @@
 package com.michelin.ns4kafka.cli.services;
 
-import com.michelin.ns4kafka.cli.FormatUtils;
 import com.michelin.ns4kafka.cli.client.ClusterResourceClient;
 import com.michelin.ns4kafka.cli.client.NamespacedResourceClient;
 import com.michelin.ns4kafka.cli.models.ApiResource;
@@ -25,6 +24,8 @@ public class ResourceService {
 
     @Inject
     LoginService loginService;
+    @Inject
+    FormatService formatService;
 
 
     public Map<ApiResource, List<Resource>> listAll(List<ApiResource> apiResources, String namespace) {
@@ -42,7 +43,7 @@ public class ResourceService {
                 return nonNamespacedClient.list(loginService.getAuthorization(), apiResource.getPath());
             }
         } catch (HttpClientResponseException e) {
-            FormatUtils.displayError(e, apiResource.getKind(), null);
+            formatService.displayError(e, apiResource.getKind(), null);
         }
         return List.of();
     }
@@ -75,7 +76,7 @@ public class ResourceService {
                 return nonNamespacedClient.apply(loginService.getAuthorization(), apiResource.getPath(), resource, dryRun);
             }
         } catch (HttpClientResponseException e) {
-            FormatUtils.displayError(e, apiResource.getKind(), resource.getMetadata().getName());
+            formatService.displayError(e, apiResource.getKind(), resource.getMetadata().getName());
         }
         return null;
     }
@@ -90,7 +91,7 @@ public class ResourceService {
                 return true;
             }
         } catch (HttpClientResponseException e) {
-            FormatUtils.displayError(e, apiResource.getKind(), resource);
+            formatService.displayError(e, apiResource.getKind(), resource);
         }
         return false;
     }
@@ -108,7 +109,7 @@ public class ResourceService {
         try {
             resources = namespacedClient.importResources(namespace, apiResource.getPath(), loginService.getAuthorization(), dryRun);
         } catch (HttpClientResponseException e) {
-            FormatUtils.displayError(e, apiResource.getKind(), null);
+            formatService.displayError(e, apiResource.getKind(), null);
             resources = List.of();
         }
 
@@ -119,7 +120,7 @@ public class ResourceService {
         try {
             return namespacedClient.deleteRecords(loginService.getAuthorization(), namespace, topic, dryrun);
         } catch (HttpClientResponseException e) {
-            FormatUtils.displayError(e, "Topic", topic);
+            formatService.displayError(e, "Topic", topic);
         }
         return null;
     }
@@ -128,7 +129,7 @@ public class ResourceService {
         try {
             return namespacedClient.resetOffsets(loginService.getAuthorization(), namespace, group, resource, dryRun);
         } catch (HttpClientResponseException e) {
-            FormatUtils.displayError(e, "ConsumerGroup", group);
+            formatService.displayError(e, "ConsumerGroup", group);
         }
         return null;
     }

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -35,8 +35,9 @@ kafkactl:
       - "AGE:/metadata/creationTimestamp%AGO"
     RoleBinding:
       - "ROLEBINDING:/metadata/name"
-      - "RESOURCES:/spec/roles/resourceTypes"
       - "GROUP:/spec/subject/subjectName"
+      - "VERBS:/spec/role/verbs"
+      - "RESOURCES:/spec/role/resourceTypes"
 #  api: http://localhost:8080
 #  user-token: token
 #  current-namespace: namespace_name

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -12,6 +12,31 @@ logger:
 kafkactl:
   version: @version@
   config-path: ${user.home}/.kafkactl
+  table-format:
+    Topic:
+      - "TOPIC:/metadata/name"
+      - "RETENTION:/spec/configs/retention.ms%PERIOD"
+      - "POLICY:/spec/configs/cleanup.policy"
+      - "AGE:/metadata/creationTimestamp%AGO"
+    AccessControlEntry:
+      - "ACL:/metadata/name"
+      - "GRANTED_BY:/metadata/namespace"
+      - "GRANTED_TO:/spec/grantedTo"
+      - "TYPE:/spec/resourceType"
+      - "RESOURCE:/spec/resource"
+      - "PATTERN:/spec/resourcePatternType"
+      - "PERMISSION:/spec/permission"
+      - "AGE:/metadata/creationTimestamp%AGO"
+    Connector:
+      - "CONNECTOR:/metadata/name"
+      - "WORKERS:/spec/connectCluster"
+      - "CLASS:/spec/config/connector.class"
+      - "TOPICS:/spec/config/topics"
+      - "AGE:/metadata/creationTimestamp%AGO"
+    RoleBinding:
+      - "NAME:/metadata/name"
+      - "RESOURCES:/spec/roles/resourceTypes"
+      - "GROUP:/spec/subject/subjectName"
 #  api: http://localhost:8080
 #  user-token: token
 #  current-namespace: namespace_name

--- a/cli/src/main/resources/application.yml
+++ b/cli/src/main/resources/application.yml
@@ -34,7 +34,7 @@ kafkactl:
       - "TOPICS:/spec/config/topics"
       - "AGE:/metadata/creationTimestamp%AGO"
     RoleBinding:
-      - "NAME:/metadata/name"
+      - "ROLEBINDING:/metadata/name"
       - "RESOURCES:/spec/roles/resourceTypes"
       - "GROUP:/spec/subject/subjectName"
 #  api: http://localhost:8080


### PR DESCRIPTION
Using a very simple formatting descriptor, provide sensible defaults to display resources by Kind.
Allow the user to override the way resources are displayed
````yaml
# config.yml
table:
- kind: Topic
  columns:
  - TOPIC:/metadata/name
  - RETENTION:/spec/configs/retention.ms%PERIOD
  - AGE:/metadata/creationTimestamp%AGO
  - CLUSTER:/metadata/cluster
- kind: Connector
  display:
  - TOPIC:/metadata/name
  - AGE:/metadata/creationTimestamp%AGO
````

````console
user@local:/home/user$ kafkactl get topic -n ixxxmfg0
  TOPIC              RETENTION  AGE                CLUSTER
  namespace.topic1   23h30m     il y a 2 semaines  if4mmfg0 
  namespace.topic2   23h30m     il y a 5 jours     if4mmfg0 
  namespace.topic3   23h30m     il y a 5 jours     if4mmfg0 
  namespace.topic4   23h30m     il y a 5 jours     if4mmfg0
  namespace.topic9   23h30m     il y a 5 jours     if4mmfg0 
  namespace.topic10  23h30m     il y a 5 jours     if4mmfg0  
````