### PR TITLE
Added Host header when fowarding to kafka connect backends

### DIFF
--- a/api/src/main/java/com/michelin/ns4kafka/services/connect/KafkaConnectClientProxy.java
+++ b/api/src/main/java/com/michelin/ns4kafka/services/connect/KafkaConnectClientProxy.java
@@ -93,6 +93,7 @@ public class KafkaConnectClientProxy extends OncePerRequestHttpServerFilter {
                                 request.getPath().substring(KafkaConnectClientProxy.PROXY_PREFIX.length())
                         ))
                 )
+                .header("Host", newURI.getHost())
                 .basicAuth(connectConfig.getBasicAuthUsername(), connectConfig.getBasicAuthPassword());
     }
 }


### PR DESCRIPTION
When ns4kafka queries kafka connect API, it keeps the original Host header which causes issues when the target endpoint is using TLS.
This fix corrects the Host header vefore contacting kafka connect