### PR TITLE
Fixed issue that prevented to delete unwanted topic configuration

### DIFF
--- a/api/src/main/java/com/michelin/ns4kafka/services/executors/TopicAsyncExecutor.java
+++ b/api/src/main/java/com/michelin/ns4kafka/services/executors/TopicAsyncExecutor.java
@@ -263,7 +263,7 @@ public class TopicAsyncExecutor {
         List<AlterConfigOp> toDelete = actual.entrySet()
                 .stream()
                 .filter(actualEntry -> !expected.containsKey(actualEntry.getKey()))
-                .map(expectedEntry -> new AlterConfigOp(new ConfigEntry(expectedEntry.getKey(),null), AlterConfigOp.OpType.DELETE))
+                .map(expectedEntry -> new AlterConfigOp(new ConfigEntry(expectedEntry.getKey(),expectedEntry.getValue()), AlterConfigOp.OpType.DELETE))
                 .collect(Collectors.toList());
         List<AlterConfigOp> toChange = expected.entrySet()
                 .stream()


### PR DESCRIPTION
````log
12:20:43.040 [scheduled-executor-thread-1] ERROR c.m.n.s.executors.TopicAsyncExecutor - Error while updating topic configs kfe.topic4demo on dkcogbl0
java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.InvalidRequestException: Invalid config value for resource ConfigResource(type=TOPIC, name='kfe.topic4demo'): null
at org.apache.kafka.common.internals.KafkaFutureImpl.wrapAndThrow(KafkaFutureImpl.java:45)
at org.apache.kafka.common.internals.KafkaFutureImpl.access$000(KafkaFutureImpl.java:32)
at org.apache.kafka.common.internals.KafkaFutureImpl$SingleWaiter.await(KafkaFutureImpl.java:104)
at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:272)
at com.michelin.ns4kafka.services.executors.TopicAsyncExecutor.lambda$alterTopics$14(TopicAsyncExecutor.java:206)
at java.base/java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1837)
at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
at com.michelin.ns4kafka.services.executors.TopicAsyncExecutor.alterTopics(TopicAsyncExecutor.java:203)
at com.michelin.ns4kafka.services.executors.TopicAsyncExecutor.synchronizeTopics(TopicAsyncExecutor.java:113)
at com.michelin.ns4kafka.services.executors.TopicAsyncExecutor.run(TopicAsyncExecutor.java:49)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
at com.michelin.ns4kafka.services.executors.KafkaAsyncExecutorScheduler.schedule(KafkaAsyncExecutorScheduler.java:41)
at com.michelin.ns4kafka.services.executors.$KafkaAsyncExecutorSchedulerDefinition$$exec2.invokeInternal(Unknown Source)
at io.micronaut.context.AbstractExecutableMethod.invoke(AbstractExecutableMethod.java:151)
at io.micronaut.inject.DelegatingExecutableMethod.invoke(DelegatingExecutableMethod.java:76)
at io.micronaut.scheduling.processor.ScheduledMethodProcessor.lambda$process$5(ScheduledMethodProcessor.java:125)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
at java.base/java.lang.Thread.run(Thread.java:831)
Caused by: org.apache.kafka.common.errors.InvalidRequestException: Invalid config value for resource ConfigResource(type=TOPIC, name='kfe.topic4demo'): null
````

This is due to AdminClient requiring the complete ConfigEntry to delete.
key : max.compaction.lag.ms 
but also value : 9223372036854775807

This PR adds the value as well so that the ConfigEntry is properly deleted