### PR TITLE
Switched to Jackson StdDateFormat to handle AGO formatting

### DIFF
--- a/cli/src/main/java/com/michelin/ns4kafka/cli/services/FormatService.java
+++ b/cli/src/main/java/com/michelin/ns4kafka/cli/services/FormatService.java
@@ -2,6 +2,7 @@ package com.michelin.ns4kafka.cli.services;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.michelin.ns4kafka.cli.KafkactlConfig;
 import com.michelin.ns4kafka.cli.models.Resource;
 import com.michelin.ns4kafka.cli.models.Status;
@@ -16,8 +17,7 @@ import picocli.CommandLine;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.time.Instant;
-import java.time.format.DateTimeParseException;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -36,7 +36,7 @@ public class FormatService {
             "KIND:/kind",
             "NAME:/metadata/name",
             "AGE:/metadata/creationTimestamp%AGO"
-            );
+    );
 
     public void displayList(String kind, List<Resource> resources, String output) {
         if (output.equals(TABLE)) {
@@ -154,31 +154,32 @@ public class FormatService {
                 switch (this.transform) {
                     case "AGO":
                         try {
-                            Date d = Date.from(Instant.parse(cell.asText()));
+                            StdDateFormat sdf = new StdDateFormat();
+                            Date d = sdf.parse(cell.asText());
                             output = new PrettyTime().format(d);
-                        } catch (DateTimeParseException e) {
-                            output = "err:" + cell;
+                        } catch ( ParseException e) {
+                            output = cell.asText();
                         }
                         break;
                     case "PERIOD":
                         try {
                             long ms = Long.parseLong(cell.asText());
                             long days = TimeUnit.MILLISECONDS.toDays(ms);
-                            long hours = TimeUnit.MILLISECONDS.toHours(ms - TimeUnit.DAYS.toMillis(days)) ;
+                            long hours = TimeUnit.MILLISECONDS.toHours(ms - TimeUnit.DAYS.toMillis(days));
                             long minutes = TimeUnit.MILLISECONDS.toMinutes(ms - TimeUnit.DAYS.toMillis(days) - TimeUnit.HOURS.toMillis(hours));
                             output = days > 0 ? (days + "d") : "";
                             output += hours > 0 ? (hours + "h") : "";
                             output += minutes > 0 ? (minutes + "m") : "";
-                        } catch (NumberFormatException e){
+                        } catch (NumberFormatException e) {
                             output = "err:" + cell;
                         }
                         break;
                     case "NONE":
                     default:
-                        if(cell.isArray()){
+                        if (cell.isArray()) {
                             List<String> childs = new ArrayList<>();
                             cell.elements().forEachRemaining(jsonNode -> childs.add(jsonNode.asText()));
-                            output = "["+String.join(",", childs)+"]";
+                            output = "[" + String.join(",", childs) + "]";
                         } else {
                             output = cell.asText();
                         }


### PR DESCRIPTION
``Instant.parse`` did not cover some date values formated like this : 
- 2021-10-13T10:10:10.000+01:00

This issue seem to occur only on some JDK and not others. Unclear.

Anyway, issue fixed by using a different formater that handles both : 
- 2021-10-13T10:10:10.000Z
- 2021-10-13T10:10:10.000+00:00

