### PR TITLE
Added Namespace and Cluster to Schema resource for AuditLog

### DIFF
--- a/api/src/main/java/com/michelin/ns4kafka/controllers/ApiResourcesController.java
+++ b/api/src/main/java/com/michelin/ns4kafka/controllers/ApiResourcesController.java
@@ -62,14 +62,14 @@ public class ApiResourcesController {
             .namespaced(true)
             .synchronizable(false)
             .path("schemas")
-            .names(List.of("schemas", "schemas", "sc"))
+            .names(List.of("schemas", "schema", "sc"))
             .build();
     public static final ResourceDefinition NAMESPACE = ResourceDefinition.builder()
             .kind("Namespace")
-                        .namespaced(false)
-                        .synchronizable(false)
-                        .path("namespaces")
-                        .names(List.of("namespaces", "namespace", "ns"))
+            .namespaced(false)
+            .synchronizable(false)
+            .path("namespaces")
+            .names(List.of("namespaces", "namespace", "ns"))
             .build();
 
     @Inject

--- a/api/src/main/java/com/michelin/ns4kafka/services/SchemaService.java
+++ b/api/src/main/java/com/michelin/ns4kafka/services/SchemaService.java
@@ -86,6 +86,8 @@ public class SchemaService {
 
         return Optional.of(Schema.builder()
                         .metadata(ObjectMeta.builder()
+                                .cluster(namespace.getMetadata().getCluster())
+                                .namespace(namespace.getMetadata().getName())
                                 .name(response.get().subject())
                                 .build())
                         .spec(Schema.SchemaSpec.builder()

--- a/api/src/test/java/com/michelin/ns4kafka/services/SchemaServiceTest.java
+++ b/api/src/test/java/com/michelin/ns4kafka/services/SchemaServiceTest.java
@@ -131,6 +131,8 @@ class SchemaServiceTest {
 
         Assertions.assertTrue(retrievedSchema.isPresent());
         Assertions.assertEquals("prefix.schema-one", retrievedSchema.get().getMetadata().getName());
+        Assertions.assertEquals("local", retrievedSchema.get().getMetadata().getCluster());
+        Assertions.assertEquals("myNamespace", retrievedSchema.get().getMetadata().getNamespace());
     }
 
     /**


### PR DESCRIPTION
Before that, audit log would display : 
`User xxxx created Schema test-value in namespace null on cluster null`