### PR TITLE
Remove requirement for name in Kafka Connect spec.config.name

### DIFF
--- a/api/src/main/java/com/michelin/ns4kafka/controllers/ConnectController.java
+++ b/api/src/main/java/com/michelin/ns4kafka/controllers/ConnectController.java
@@ -79,6 +79,16 @@ public class ConnectController extends NamespacedResourceController {
                     " for name: Namespace not OWNER of this connector"), connector.getKind(), connector.getMetadata().getName());
         }
 
+        // Set / Override name in spec.config.name, required for several Kafka Connect API calls
+        // This is a response to projects setting a value A in metadata.name, and a value B in spec.config.name
+        // I have considered alternatives :
+        // - Make name in spec.config forbidden, and set it only when necessary (API calls)
+        // - Mask it in the resulting list connectors so that the synchronization process doesn't see changes
+        // I prefer to go this way for 2 reasons:
+        // - It is backward compatible with teams that already define name in spec.config.name
+        // - It doesn't impact the code as much (single line vs 10+ lines)
+        connector.getSpec().getConfig().put("name", connector.getMetadata().getName());
+
         // Validate locally
         List<String> validationErrors = kafkaConnectService.validateLocally(ns, connector);
         if (!validationErrors.isEmpty()) {

--- a/api/src/test/java/com/michelin/ns4kafka/controllers/ConnectControllerTest.java
+++ b/api/src/test/java/com/michelin/ns4kafka/controllers/ConnectControllerTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -194,7 +195,10 @@ public class ConnectControllerTest {
 
     @Test
     void createConnectorLocalErrors() {
-        Connector connector = Connector.builder().metadata(ObjectMeta.builder().name("connect1").build()).build();
+        Connector connector = Connector.builder()
+                .metadata(ObjectMeta.builder().name("connect1").build())
+                .spec(Connector.ConnectorSpec.builder().config(new HashMap<>()).build())
+                .build();
 
         Namespace ns = Namespace.builder()
                 .metadata(ObjectMeta.builder()
@@ -215,7 +219,10 @@ public class ConnectControllerTest {
 
     @Test
     void createConnectorRemoteErrors() {
-        Connector connector = Connector.builder().metadata(ObjectMeta.builder().name("connect1").build()).build();
+        Connector connector = Connector.builder()
+                .metadata(ObjectMeta.builder().name("connect1").build())
+                .spec(Connector.ConnectorSpec.builder().config(new HashMap<>()).build())
+                .build();
 
         Namespace ns = Namespace.builder()
                 .metadata(ObjectMeta.builder()
@@ -238,9 +245,13 @@ public class ConnectControllerTest {
 
     @Test
     void createConnectorSuccess() {
-        Connector connector = Connector.builder().metadata(ObjectMeta.builder().name("connect1").build()).build();
+        Connector connector = Connector.builder()
+                .metadata(ObjectMeta.builder().name("connect1").build())
+                .spec(Connector.ConnectorSpec.builder().config(new HashMap<>()).build())
+                .build();
         Connector expected = Connector.builder()
                 .metadata(ObjectMeta.builder().name("connect1").build())
+                .spec(Connector.ConnectorSpec.builder().config(Map.of("name", "connect1")).build())
                 .status(Connector.ConnectorStatus.builder().state(Connector.TaskState.UNASSIGNED).build())
                 .build();
 
@@ -274,12 +285,16 @@ public class ConnectControllerTest {
 
     @Test
     void createConnectorSuccess_AlreadyExists() {
-        Connector connector = Connector.builder().metadata(ObjectMeta.builder().name("connect1").build()).build();
+        Connector connector = Connector.builder()
+                .metadata(ObjectMeta.builder().name("connect1").build())
+                .spec(Connector.ConnectorSpec.builder().config(new HashMap<>()).build())
+                .build();
         Connector expected = Connector.builder()
                 .metadata(ObjectMeta.builder()
                         .namespace("test")
                         .cluster("local")
                         .name("connect1").build())
+                .spec(Connector.ConnectorSpec.builder().config(Map.of("name", "connect1")).build())
                 .status(Connector.ConnectorStatus.builder().state(Connector.TaskState.UNASSIGNED).build())
                 .build();
 
@@ -311,10 +326,17 @@ public class ConnectControllerTest {
 
     @Test
     void createConnectorSuccess_Changed() {
-        Connector connector = Connector.builder().metadata(ObjectMeta.builder().name("connect1").build()).build();
+        Connector connector = Connector.builder()
+                .metadata(ObjectMeta.builder().name("connect1").build())
+                .spec(Connector.ConnectorSpec.builder().config(new HashMap<>()).build())
+                .build();
         Connector connectorOld = Connector.builder().metadata(ObjectMeta.builder().name("connect1").labels(Map.of("label", "labelValue")).build()).build();
         Connector expected = Connector.builder()
-                .metadata(ObjectMeta.builder().name("connect1").build())
+                .metadata(ObjectMeta.builder()
+                        .name("connect1")
+                        .labels(Map.of("label", "labelValue"))
+                        .build())
+                .spec(Connector.ConnectorSpec.builder().config(Map.of("name", "connect1")).build())
                 .status(Connector.ConnectorStatus.builder().state(Connector.TaskState.UNASSIGNED).build())
                 .build();
 
@@ -344,15 +366,19 @@ public class ConnectControllerTest {
         Connector actual = response.body();
 
         Assertions.assertEquals("changed", response.header("X-Ns4kafka-Result"));
-        Assertions.assertEquals(expected.getStatus().getState(), actual.getStatus().getState());
+        Assertions.assertEquals(expected, actual);
 
     }
 
     @Test
     void createConnectorDryRun() {
-        Connector connector = Connector.builder().metadata(ObjectMeta.builder().name("connect1").build()).build();
+        Connector connector = Connector.builder()
+                .metadata(ObjectMeta.builder().name("connect1").build())
+                .spec(Connector.ConnectorSpec.builder().config(new HashMap<>()).build())
+                .build();
         Connector expected = Connector.builder()
                 .metadata(ObjectMeta.builder().name("connect1").build())
+                .spec(Connector.ConnectorSpec.builder().config(Map.of("name", "connect1")).build())
                 .status(Connector.ConnectorStatus.builder().state(Connector.TaskState.UNASSIGNED).build())
                 .build();
 

--- a/api/src/test/java/com/michelin/ns4kafka/integration/ConnectTest.java
+++ b/api/src/test/java/com/michelin/ns4kafka/integration/ConnectTest.java
@@ -176,7 +176,6 @@ public class ConnectTest extends AbstractIntegrationConnectTest {
                         .connectCluster("test-connect")
                         .config(Map.of(
                                 "connector.class", "org.apache.kafka.connect.file.FileStreamSinkConnector",
-                                "name", "ns1-co1",
                                 "tasks.max", "1",
                                 "topics", "ns1-to1"
                         ))
@@ -225,7 +224,6 @@ public class ConnectTest extends AbstractIntegrationConnectTest {
                         .connectCluster("test-connect")
                         .config(Map.of(
                                 "connector.class", "org.apache.kafka.connect.file.FileStreamSinkConnector",
-                                "name", "ns1-co2",
                                 "tasks.max", "3",
                                 "topics", "ns1-to1"
                         ))


### PR DESCRIPTION
Closes #150 