### PR TITLE
Make kafkactl get schemas return only names

### DIFF
--- a/api/src/main/java/com/michelin/ns4kafka/services/SchemaService.java
+++ b/api/src/main/java/com/michelin/ns4kafka/services/SchemaService.java
@@ -57,9 +57,13 @@ public class SchemaService {
                         return false;
                     });
                 })
-                .map(namespacedSubject -> getLatestSubject(namespace, namespacedSubject))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .map(namespacedSubject -> Schema.builder()
+                    .metadata(ObjectMeta.builder()
+                            .cluster(namespace.getMetadata().getCluster())
+                            .namespace(namespace.getMetadata().getName())
+                            .name(namespacedSubject)
+                            .build())
+                    .build())
                 .collect(Collectors.toList());
     }
 

--- a/api/src/test/java/com/michelin/ns4kafka/services/SchemaServiceTest.java
+++ b/api/src/test/java/com/michelin/ns4kafka/services/SchemaServiceTest.java
@@ -53,9 +53,6 @@ class SchemaServiceTest {
         SchemaCompatibilityResponse compatibilityResponse = this.buildCompatibilityResponse();
 
         when(kafkaSchemaRegistryClient.getSubjects(KafkaSchemaRegistryClientProxy.PROXY_SECRET, namespace.getMetadata().getCluster())).thenReturn(subjectsResponse);
-        when(kafkaSchemaRegistryClient.getLatestSubject(KafkaSchemaRegistryClientProxy.PROXY_SECRET, namespace.getMetadata().getCluster(), "prefix.schema-one")).thenReturn(Optional.of(this.buildSchemaResponse("prefix.schema-one")));
-        when(kafkaSchemaRegistryClient.getLatestSubject(KafkaSchemaRegistryClientProxy.PROXY_SECRET, namespace.getMetadata().getCluster(), "prefix2.schema-two")).thenReturn(Optional.of(this.buildSchemaResponse("prefix2.schema-two")));
-        when(kafkaSchemaRegistryClient.getCurrentCompatibilityBySubject(any(), any(), any())).thenReturn(Optional.of(compatibilityResponse));
         Mockito.when(accessControlEntryService.findAllGrantedToNamespace(namespace))
                 .thenReturn(List.of(
                         AccessControlEntry.builder()


### PR DESCRIPTION
Currently, `kafkactl get schemas` returns the schemas name, version, id, and compatibility mode. It's great but if the namespace owns 100's of schemas, the performance is very poor.
Since ns4kafka doesn't cache registry call, it makes more sense for now to simply list the subjects names available (and nothing else)