### PR TITLE
Added producer/consumer byte rate client quota customization

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/models/Namespace.java
+++ b/src/main/java/com/michelin/ns4kafka/models/Namespace.java
@@ -12,7 +12,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.util.List;
-import java.util.Map;
 
 @Data
 @Builder
@@ -38,8 +37,6 @@ public class Namespace {
     public static class NamespaceSpec {
         @NotBlank
         private String kafkaUser;
-        @Builder.Default
-        private Map<String, Double> kafkaUserQuota = Map.of();
         @Builder.Default
         private List<String> connectClusters = List.of();
         private TopicValidator topicValidator;

--- a/src/main/java/com/michelin/ns4kafka/models/Namespace.java
+++ b/src/main/java/com/michelin/ns4kafka/models/Namespace.java
@@ -12,6 +12,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Map;
 
 @Data
 @Builder
@@ -37,6 +38,8 @@ public class Namespace {
     public static class NamespaceSpec {
         @NotBlank
         private String kafkaUser;
+        @Builder.Default
+        private Map<String, Double> kafkaUserQuota = Map.of();
         @Builder.Default
         private List<String> connectClusters = List.of();
         private TopicValidator topicValidator;

--- a/src/main/java/com/michelin/ns4kafka/models/quota/ResourceQuota.java
+++ b/src/main/java/com/michelin/ns4kafka/models/quota/ResourceQuota.java
@@ -32,7 +32,9 @@ public class ResourceQuota {
         COUNT_TOPICS("count/topics"),
         COUNT_PARTITIONS("count/partitions"),
         DISK_TOPICS("disk/topics"),
-        COUNT_CONNECTORS("count/connectors");
+        COUNT_CONNECTORS("count/connectors"),
+        USER_PRODUCER_BYTE_RATE("user/producer_byte_rate"),
+        USER_CONSUMER_BYTE_RATE("user/consumer_byte_rate");
 
         private final String key;
 

--- a/src/main/java/com/michelin/ns4kafka/models/quota/ResourceQuotaResponse.java
+++ b/src/main/java/com/michelin/ns4kafka/models/quota/ResourceQuotaResponse.java
@@ -35,5 +35,7 @@ public class ResourceQuotaResponse {
         private String countPartition;
         private String diskTopic;
         private String countConnector;
+        private String consumerByteRate;
+        private String producerByteRate;
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/services/executors/UserAsyncExecutor.java
+++ b/src/main/java/com/michelin/ns4kafka/services/executors/UserAsyncExecutor.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
 @EachBean(KafkaAsyncExecutorConfig.class)
 @Singleton
 public class UserAsyncExecutor {
+    private static final String USER_QUOTA_PREFIX = "user/";
+
     private final KafkaAsyncExecutorConfig kafkaAsyncExecutorConfig;
 
     private final AbstractUserSynchronizer userExecutor;
@@ -109,9 +111,9 @@ public class UserAsyncExecutor {
 
                     quota.ifPresent(resourceQuota -> resourceQuota.getSpec().entrySet()
                             .stream()
-                            .filter(q -> q.getKey().startsWith("user/"))
+                            .filter(q -> q.getKey().startsWith(USER_QUOTA_PREFIX))
                             .forEach(q -> userQuota.put(
-                                    q.getKey().replaceAll("user/", ""),
+                                    q.getKey().replaceAll(USER_QUOTA_PREFIX, ""),
                                     Double.parseDouble(q.getValue()))));
 
                     return Map.entry(namespace.getSpec().getKafkaUser(), userQuota);

--- a/src/main/java/com/michelin/ns4kafka/services/executors/UserAsyncExecutor.java
+++ b/src/main/java/com/michelin/ns4kafka/services/executors/UserAsyncExecutor.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
 @EachBean(KafkaAsyncExecutorConfig.class)
 @Singleton
 public class UserAsyncExecutor {
+    public static final double BYTE_RATE_DEFAULT_VALUE = 102400.0;
+
     private static final String USER_QUOTA_PREFIX = "user/";
 
     private final KafkaAsyncExecutorConfig kafkaAsyncExecutorConfig;
@@ -199,8 +201,8 @@ public class UserAsyncExecutor {
         @Override
         public void applyQuotas(String user, Map<String, Double> quotas) {
             ClientQuotaEntity client = new ClientQuotaEntity(Map.of("user", user));
-            ClientQuotaAlteration.Op producerQuota = new ClientQuotaAlteration.Op("producer_byte_rate", quotas.getOrDefault("producer_byte_rate", 102400.0));
-            ClientQuotaAlteration.Op consumerQuota = new ClientQuotaAlteration.Op("consumer_byte_rate", quotas.getOrDefault("consumer_byte_rate", 102400.0));
+            ClientQuotaAlteration.Op producerQuota = new ClientQuotaAlteration.Op("producer_byte_rate", quotas.getOrDefault("producer_byte_rate", BYTE_RATE_DEFAULT_VALUE));
+            ClientQuotaAlteration.Op consumerQuota = new ClientQuotaAlteration.Op("consumer_byte_rate", quotas.getOrDefault("consumer_byte_rate", BYTE_RATE_DEFAULT_VALUE));
             ClientQuotaAlteration clientQuota = new ClientQuotaAlteration(client, List.of(producerQuota, consumerQuota));
             try {
                 admin.alterClientQuotas(List.of(clientQuota)).all().get(10, TimeUnit.SECONDS);

--- a/src/test/java/com/michelin/ns4kafka/services/ResourceQuotaServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/services/ResourceQuotaServiceTest.java
@@ -494,6 +494,58 @@ class ResourceQuotaServiceTest {
     }
 
     /**
+     * Test validation errors when creating quota on user/consumer_byte_rate with string instead of number
+     */
+    @Test
+    void validateUserQuotaFormatError() {
+        Namespace ns = Namespace.builder()
+                .metadata(ObjectMeta.builder()
+                        .name("namespace")
+                        .cluster("local")
+                        .build())
+                .build();
+
+        ResourceQuota resourceQuota = ResourceQuota.builder()
+                .metadata(ObjectMeta.builder()
+                        .cluster("local")
+                        .name("test")
+                        .build())
+                .spec(Map.of(USER_PRODUCER_BYTE_RATE.toString(), "producer", USER_CONSUMER_BYTE_RATE.toString(), "consumer"))
+                .build();
+
+        List<String> validationErrors = resourceQuotaService.validateNewResourceQuota(ns, resourceQuota);
+
+        Assertions.assertEquals(2, validationErrors.size());
+        Assertions.assertEquals("Number expected for user/producer_byte_rate (producer given)", validationErrors.get(0));
+        Assertions.assertEquals("Number expected for user/consumer_byte_rate (consumer given)", validationErrors.get(1));
+    }
+
+    /**
+     * Test validation when creating quota on user/consumer_byte_rate
+     */
+    @Test
+    void validateUserQuotaFormatSuccess() {
+        Namespace ns = Namespace.builder()
+                .metadata(ObjectMeta.builder()
+                        .name("namespace")
+                        .cluster("local")
+                        .build())
+                .build();
+
+        ResourceQuota resourceQuota = ResourceQuota.builder()
+                .metadata(ObjectMeta.builder()
+                        .cluster("local")
+                        .name("test")
+                        .build())
+                .spec(Map.of(USER_PRODUCER_BYTE_RATE.toString(), "102400", USER_CONSUMER_BYTE_RATE.toString(), "102400"))
+                .build();
+
+        List<String> validationErrors = resourceQuotaService.validateNewResourceQuota(ns, resourceQuota);
+
+        Assertions.assertEquals(0, validationErrors.size());
+    }
+
+    /**
      * Test get current used resource for count topics
      */
     @Test


### PR DESCRIPTION
- Adding client quota customization
```yaml
---
apiVersion: v1
kind: Namespace
metadata:
  name: myNamespace
  cluster: cluster1
spec:
  kafkaUser: kafkaServiceAccount
  kafkaUserQuota:
    producer_byte_rate: 204800
    consumer_byte_rate: 409600
```

- Fixing update user quota filtering. Update has to be performed if namespace user quota definition is different from the broker user quota
- Adding integration tests for both custom quota and quota updates

**Note**: at the beginning I was thinking of specifying the user quota like this
```yaml
---
apiVersion: v1
kind: Namespace
metadata:
  name: myNamespace
  cluster: cluster1
spec:
  kafkaUser: 
    name: kafkaServiceAccount
    producer_byte_rate: 204800
    consumer_byte_rate: 409600
```
But this format would have broken the namespace unmarshalling with existing namespace definition.
I was also thinking of creating a apiVersion 2 for namespace definition, Namespace v2 model, etc. but kept a simplier approach by adding a new configuration key. 
Tell me what you prefer... ! 

When it will be merged I'll created a PR oin kafkactl to update to Readme accordingly