### PR TITLE
Add key/value suffix for schema filtering on LITERAL ACL on v3 claim

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controllers/AkhqClaimProviderController.java
+++ b/src/main/java/com/michelin/ns4kafka/controllers/AkhqClaimProviderController.java
@@ -189,13 +189,24 @@ public class AkhqClaimProviderController {
 
         // Add the same pattern and cluster filtering for SCHEMA as the TOPIC ones
         result.addAll(result.stream()
-            .filter(g -> g.role.equals(config.getRoles().get(AccessControlEntry.ResourceType.TOPIC)))
-            .map(g -> AkhqClaimResponseV3.Group.builder()
-                .role(config.getRoles().get(AccessControlEntry.ResourceType.SCHEMA))
-                .patterns(g.getPatterns())
-                .clusters(g.getClusters())
-                .build()
-            ).toList());
+                .filter(g -> g.role.equals(config.getRoles().get(AccessControlEntry.ResourceType.TOPIC)))
+                .map(g -> {
+                            List<String> patterns = new ArrayList<>(
+                                    g.getPatterns().stream().filter(p -> p.contains(".*")).toList());
+
+                            // For literal Topic ACL, we need to add the -key or -value prefix to the schema pattern
+                            patterns.addAll(g.getPatterns().stream()
+                                    .filter(p -> !p.contains(".*"))
+                                    .map(p -> p.replace("\\E$", "-\\E(key|value)$"))
+                                    .toList());
+
+                            return AkhqClaimResponseV3.Group.builder()
+                                    .role(config.getRoles().get(AccessControlEntry.ResourceType.SCHEMA))
+                                    .patterns(patterns)
+                                    .clusters(g.getClusters())
+                                    .build();
+                        }
+                ).toList());
 
         return AkhqClaimResponseV3.builder()
             .groups(result.isEmpty() ? null : Map.of("group", result))

--- a/src/main/java/com/michelin/ns4kafka/controllers/AkhqClaimProviderController.java
+++ b/src/main/java/com/michelin/ns4kafka/controllers/AkhqClaimProviderController.java
@@ -191,12 +191,13 @@ public class AkhqClaimProviderController {
         result.addAll(result.stream()
                 .filter(g -> g.role.equals(config.getRoles().get(AccessControlEntry.ResourceType.TOPIC)))
                 .map(g -> {
+                            // Takes all the PREFIXED patterns as-is
                             List<String> patterns = new ArrayList<>(
-                                    g.getPatterns().stream().filter(p -> p.contains(".*")).toList());
+                                    g.getPatterns().stream().filter(p -> p.endsWith("\\E.*$")).toList());
 
-                            // For literal Topic ACL, we need to add the -key or -value prefix to the schema pattern
+                            // Add -key or -value prefix to the schema pattern for LITERAL patterns
                             patterns.addAll(g.getPatterns().stream()
-                                    .filter(p -> !p.contains(".*"))
+                                    .filter(p -> p.endsWith("\\E$"))
                                     .map(p -> p.replace("\\E$", "-\\E(key|value)$"))
                                     .toList());
 

--- a/src/test/java/com/michelin/ns4kafka/controllers/AkhqClaimProviderControllerV3Test.java
+++ b/src/test/java/com/michelin/ns4kafka/controllers/AkhqClaimProviderControllerV3Test.java
@@ -493,8 +493,8 @@ class AkhqClaimProviderControllerV3Test {
         );
         Assertions.assertEquals("registry-read", groups.get(2).getRole());
         Assertions.assertEquals(
-            List.of("^\\Qproject1.\\E.*$", "^\\Qproject2.topic2\\E$", "^\\Qproject2.topic2a\\E$",
-                "^\\Qproject2.topic3\\E$", "^\\Qproject3.\\E.*$"),
+            List.of("^\\Qproject1.\\E.*$", "^\\Qproject3.\\E.*$", "^\\Qproject2.topic2-\\E(key|value)$",
+                    "^\\Qproject2.topic2a-\\E(key|value)$", "^\\Qproject2.topic3-\\E(key|value)$"),
             groups.get(2).getPatterns()
         );
     }


### PR DESCRIPTION
We decided during the v3 endpoint creation to add the same filtering on schema than on topics (see [here](https://github.com/michelin/ns4kafka/pull/297#discussion_r1258401210))

We figured out that a bug appears with LITERAL ACL because we will set the same pattern for "registry-read" role on these ACL (ex: `"^\\Qproject.topic\\E$"`). The filtering on schemas list searches literally for schema with the `project.topic` name which is incorrect because schemas will be named `project.topic-key` or `project.topic-value`

This PR fixes the issue by updating the pattern for patterns that do not contain `.*` (pattern for prefixed ACL).  Then, literal pattern `"^\\Qproject.topic\\E$"` becomes `"^\\Qproject.topic-\\E(key|value)$"`