### PR TITLE
Fix topic with Confluent tag being recreated after deletion

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutor.java
+++ b/src/main/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutor.java
@@ -194,10 +194,6 @@ public class TopicAsyncExecutor {
 
         log.info("Success deleting topic {} on {}", topic.getMetadata().getName(),
             managedClusterProperties.getName());
-
-        if (managedClusterProperties.isConfluentCloud() && !topic.getSpec().getTags().isEmpty()) {
-            dissociateTags(topic.getSpec().getTags(), topic);
-        }
     }
 
     /**

--- a/src/test/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutorTest.java
@@ -540,13 +540,13 @@ class TopicAsyncExecutorTest {
         assertTrue(brokerTopics.get(TOPIC_NAME).getSpec().getTags().isEmpty());
 
         assertNull(brokerTopics.get(TOPIC_NAME2).getSpec().getDescription());
-        assertEquals(TAG1, brokerTopics.get(TOPIC_NAME2).getSpec().getTags().get(0));
+        assertEquals(TAG1, brokerTopics.get(TOPIC_NAME2).getSpec().getTags().getFirst());
 
         assertEquals(DESCRIPTION1, brokerTopics.get(TOPIC_NAME3).getSpec().getDescription());
         assertTrue(brokerTopics.get(TOPIC_NAME3).getSpec().getTags().isEmpty());
 
         assertEquals(DESCRIPTION2, brokerTopics.get(TOPIC_NAME4).getSpec().getDescription());
-        assertEquals(TAG2, brokerTopics.get(TOPIC_NAME4).getSpec().getTags().get(0));
+        assertEquals(TAG2, brokerTopics.get(TOPIC_NAME4).getSpec().getTags().getFirst());
     }
 
     @Test


### PR DESCRIPTION
When a tagged topic is deleted, it is recreated. This MR fixes that issue.