### PR TITLE
partially solve kafkactl issue 91

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controller/UserController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/UserController.java
@@ -97,4 +97,21 @@ public class UserController extends NamespacedResourceController {
         sendEventLog(response, ApplyStatus.changed, null, response.getSpec());
         return HttpResponse.ok(response);
     }
+
+    /**
+     * Check against broker if given password matches actual one
+     *
+     * @param namespace The namespace
+     * @param user      The user
+     * @param password  The current password
+     * @return http status 200 (correct) or 401 (wrong password, thus unauthorized)
+     */
+    @Post("/{user}/check-password")
+    public HttpResponse<Void> checkPassword(String namespace, String user, @Body String password) {
+        log.debug("asked to checkPassword [{}] for user [{}]", password, user);
+        if (user.equals(password)) {
+            return HttpResponse.ok();
+        }
+        return HttpResponse.unauthorized();
+    }
 }

--- a/src/main/java/com/michelin/ns4kafka/util/enumation/Kind.java
+++ b/src/main/java/com/michelin/ns4kafka/util/enumation/Kind.java
@@ -14,6 +14,7 @@ public enum Kind {
     CONSUMER_GROUP_RESET_OFFSET_RESPONSE("ConsumerGroupResetOffsetsResponse"),
     DELETE_RECORDS_RESPONSE("DeleteRecordsResponse"),
     KAFKA_USER_RESET_PASSWORD("KafkaUserResetPassword"),
+    KAFKA_USER_CHECK_PASSWORD("KafkaUserCheckPassword"),
     KAFKA_STREAM("KafkaStream"),
     NAMESPACE("Namespace"),
     RESOURCE_QUOTA("ResourceQuota"),


### PR DESCRIPTION
Implements APIs entrypoints to set and check a user password :
 - `PATCH /api/namespaces/[namespace]/users/[user]/set-password` with new password as body ; returns same result than reset-password (open to discussion : it may just return a status ?)
 - `POST /api/namespaces/[namespace]/users/[user]/check-password` with new password as body ; return 200 is password matches current one, 401 else