### PR TITLE
Find namespace from topic name

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controller/NamespaceController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/NamespaceController.java
@@ -24,6 +24,7 @@ import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -39,14 +40,21 @@ public class NamespaceController extends NonNamespacedResourceController {
     NamespaceService namespaceService;
 
     /**
-     * List namespaces, filtered by name parameter.
+     * List namespaces, filtered by namespace name and topic name parameters.
      *
-     * @param name The name parameter
+     * @param name  The namespace name parameter
+     * @param topic The topic name parameter
      * @return A list of namespaces
      */
     @Get
-    public List<Namespace> list(@QueryValue(defaultValue = "*") String name) {
-        return namespaceService.findByWildcardName(name);
+    public List<Namespace> list(@QueryValue(defaultValue = "*") String name,
+                                @QueryValue(defaultValue = "") String topic) {
+        List<Namespace> namespaces = namespaceService.findByWildcardName(name);
+
+        return topic.isEmpty() ? namespaces :
+            namespaceService.findByTopicName(namespaces, topic)
+                .map(Collections::singletonList)
+                .orElse(List.of());
     }
 
     /**

--- a/src/main/java/com/michelin/ns4kafka/service/AclService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/AclService.java
@@ -366,7 +366,7 @@ public class AclService {
     }
 
     /**
-     * Find all owner-ACLs on a resource for a given namespace.
+     * Find all owner-ACLs on a resource granted to a given namespace.
      *
      * @param namespace    The namespace
      * @param resourceType The resource
@@ -376,10 +376,9 @@ public class AclService {
                                                                         AccessControlEntry.ResourceType resourceType) {
         return accessControlEntryRepository.findAll()
             .stream()
-            .filter(accessControlEntry ->
-                accessControlEntry.getSpec().getGrantedTo().equals(namespace.getMetadata().getName())
-                    && accessControlEntry.getSpec().getPermission() == AccessControlEntry.Permission.OWNER
-                    && accessControlEntry.getSpec().getResourceType() == resourceType)
+            .filter(acl -> acl.getSpec().getGrantedTo().equals(namespace.getMetadata().getName())
+                && acl.getSpec().getPermission() == AccessControlEntry.Permission.OWNER
+                && acl.getSpec().getResourceType() == resourceType)
             .toList();
     }
 

--- a/src/main/java/com/michelin/ns4kafka/service/NamespaceService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/NamespaceService.java
@@ -9,6 +9,7 @@ import static com.michelin.ns4kafka.util.enumation.Kind.RESOURCE_QUOTA;
 import static com.michelin.ns4kafka.util.enumation.Kind.ROLE_BINDING;
 import static com.michelin.ns4kafka.util.enumation.Kind.TOPIC;
 
+import com.michelin.ns4kafka.model.AccessControlEntry;
 import com.michelin.ns4kafka.model.Namespace;
 import com.michelin.ns4kafka.property.ManagedClusterProperties;
 import com.michelin.ns4kafka.repository.NamespaceRepository;
@@ -78,6 +79,21 @@ public class NamespaceService {
             .stream()
             .filter(ns -> RegexUtils.isResourceCoveredByRegex(ns.getMetadata().getName(), nameFilterPatterns))
             .toList();
+    }
+
+    /**
+     * Find the namespace which are owner of the given topic name, out of the given list.
+     *
+     * @param namespaces The namespaces list
+     * @param topic      The topic name to search
+     * @return The namespace which is owner of the given topic name
+     */
+    public Optional<Namespace> findByTopicName(List<Namespace> namespaces, String topic) {
+        return namespaces
+            .stream()
+            .filter(ns -> aclService.isResourceCoveredByAcls(
+                aclService.findResourceOwnerGrantedToNamespace(ns, AccessControlEntry.ResourceType.TOPIC), topic))
+            .findFirst();
     }
 
     /**

--- a/src/test/java/com/michelin/ns4kafka/controller/NamespaceControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/NamespaceControllerTest.java
@@ -60,7 +60,7 @@ class NamespaceControllerTest {
         when(namespaceService.findByWildcardName("*"))
             .thenReturn(List.of(ns1, ns2));
 
-        assertEquals(List.of(ns1, ns2), namespaceController.list("*"));
+        assertEquals(List.of(ns1, ns2), namespaceController.list("*", ""));
     }
 
     @Test
@@ -74,13 +74,45 @@ class NamespaceControllerTest {
         when(namespaceService.findByWildcardName("ns"))
             .thenReturn(List.of(ns));
 
-        assertEquals(List.of(ns), namespaceController.list("ns"));
+        assertEquals(List.of(ns), namespaceController.list("ns", ""));
+    }
+
+    @Test
+    void shouldListNamespaceFilteredByTopic() {
+        Namespace ns = Namespace.builder()
+            .metadata(Metadata.builder()
+                .name("ns")
+                .build())
+            .build();
+
+        when(namespaceService.findByWildcardName("*"))
+            .thenReturn(List.of(ns));
+        when(namespaceService.findByTopicName(List.of(ns), "topic"))
+            .thenReturn(Optional.of(ns));
+
+        assertEquals(List.of(ns), namespaceController.list("*", "topic"));
+    }
+
+    @Test
+    void shouldListNoNamespaceFilteredByTopic() {
+        Namespace ns = Namespace.builder()
+            .metadata(Metadata.builder()
+                .name("ns")
+                .build())
+            .build();
+
+        when(namespaceService.findByWildcardName("*"))
+            .thenReturn(List.of(ns));
+        when(namespaceService.findByTopicName(List.of(ns), "topic"))
+            .thenReturn(Optional.empty());
+
+        assertEquals(List.of(), namespaceController.list("*", "topic"));
     }
 
     @Test
     void shouldListNamespacesWhenEmpty() {
         when(namespaceService.findByWildcardName("*")).thenReturn(List.of());
-        assertEquals(List.of(), namespaceController.list("*"));
+        assertEquals(List.of(), namespaceController.list("*", ""));
     }
 
     @Test


### PR DESCRIPTION
Add the possibility to find the namespace which is the owner of a topic, thanks to a given topic name.

The PR adds the `topic` query parameter in the LIST namespace API:
- if the query parameter is an empty string, the endpoint doesn't filter at all by the topic name.
- if the query parameter is not empty, the endpoint finds the namespace which is the owner of the topic. It returns no namespace if no namespace is owner of the topic (or the topic doesn't exist).

Maybe, the implementation could be 2 additional parameters, resource type and resource name, to allow the search on all types of resources (not only topics), I left it to discussion.