### PR TITLE
Improve JWT format with namespaces grouping

### DIFF
--- a/.docker/resources/admin/another-namespace2.yml
+++ b/.docker/resources/admin/another-namespace2.yml
@@ -1,0 +1,147 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: anotherNamespace
+  cluster: local
+  labels:
+    contacts: namespace.owner@example.com
+spec:
+  kafkaUser: user2
+  connectClusters:
+    - local
+  topicValidator:
+    validationConstraints:
+      partitions:
+        validation-type: Range
+        min: 1
+        max: 6
+      replication.factor:
+        validation-type: Range
+        min: 1
+        max: 1
+      min.insync.replicas:
+        validation-type: Range
+        min: 1
+        max: 1
+      retention.ms:
+        optional: true
+        validation-type: Range
+        min: 60000
+        max: 604800000
+      cleanup.policy:
+        validation-type: ValidList
+        validStrings:
+          - delete
+          - compact
+  connectValidator:
+    validationConstraints:
+      key.converter:
+        validation-type: NonEmptyString
+      value.converter:
+        validation-type: NonEmptyString
+      connector.class:
+        validation-type: ValidString
+        validStrings:
+          - io.confluent.connect.jdbc.JdbcSinkConnector
+          - io.confluent.connect.jdbc.JdbcSourceConnector
+          - io.confluent.kafka.connect.datagen.DatagenConnector
+    classValidationConstraints:
+      io.confluent.kafka.connect.datagen.DatagenConnector:
+        schema.string:
+          validation-type: NonEmptyString
+        schema.keyfield:
+          validation-type: NonEmptyString
+---
+apiVersion: v1
+kind: RoleBinding
+metadata:
+  name: anotherRoleBinding1
+  namespace: anotherNamespace
+spec:
+  role:
+    resourceTypes:
+    - schemas
+    - schemas/config
+    - topics
+    - topics/import
+    - topics/delete-records
+    - connectors
+    - connectors/import
+    - connectors/change-state
+    - connect-clusters
+    - connect-clusters/vaults
+    - acls
+    - consumer-groups/reset
+    - streams
+    verbs:
+    - GET
+    - POST
+    - PUT
+    - DELETE
+  subject:
+    subjectType: GROUP
+    subjectName: DEV
+---
+apiVersion: v1
+kind: RoleBinding
+metadata:
+  name: anotherRoleBinding2
+  namespace: anotherNamespace
+spec:
+  role:
+    resourceTypes:
+    - quota
+    verbs:
+    - GET
+  subject:
+    subjectType: GROUP
+    subjectName: DEV
+---
+apiVersion: v1
+kind: AccessControlEntry
+metadata:
+  name: anotherTopicAcl
+  namespace: anotherNamespace
+spec:
+  resourceType: TOPIC
+  resource: def.
+  resourcePatternType: PREFIXED
+  permission: OWNER
+  grantedTo: anotherNamespace
+---
+apiVersion: v1
+kind: AccessControlEntry
+metadata:
+  name: anotherGroupAcl
+  namespace: anotherNamespace
+spec:
+  resourceType: GROUP
+  resource: def.
+  resourcePatternType: PREFIXED
+  permission: OWNER
+  grantedTo: anotherNamespace
+---
+apiVersion: v1
+kind: AccessControlEntry
+metadata:
+  name: anotherConnectAcl
+  namespace: anotherNamespace
+spec:
+  resourceType: CONNECT
+  resource: def.
+  resourcePatternType: PREFIXED
+  permission: OWNER
+  grantedTo: anotherNamespace
+---
+apiVersion: v1
+kind: AccessControlEntry
+metadata:
+  name: anotherConnectClusterAcl
+  namespace: anotherNamespace
+spec:
+  resourceType: CONNECT_CLUSTER
+  resource: def.
+  resourcePatternType: PREFIXED
+  permission: OWNER
+  grantedTo: anotherNamespace

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The delivered JWT token will have the following format:
 {
   "roleBindings": [
     {
-      "namespace": "myNamespace",
+      "namespaces": ["myNamespace"],
       "verbs": [
         "GET",
         "POST",
@@ -165,16 +165,14 @@ The delivered JWT token will have the following format:
         "schemas",
         "schemas/config",
         "topics",
-        "topics/import",
         "topics/delete-records",
         "connectors",
-        "connectors/import",
         "connectors/change-state",
-        "connect-clusters",
-        "connect-clusters/vaults",
         "acls",
         "consumer-groups/reset",
-        "streams"
+        "streams",
+        "connect-clusters",
+        "connect-clusters/vaults"
       ]
     }
   ],

--- a/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
+++ b/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
@@ -1,6 +1,7 @@
 package com.michelin.ns4kafka.security;
 
 import static com.michelin.ns4kafka.security.auth.JwtCustomClaimNames.ROLE_BINDINGS;
+import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
 
 import com.michelin.ns4kafka.model.RoleBinding;
 import com.michelin.ns4kafka.property.SecurityProperties;
@@ -110,7 +111,9 @@ public class ResourceBasedSecurityRule implements SecurityRule<HttpRequest<?>> {
         // No role binding for the target namespace. User is targeting a namespace that he is not allowed to access
         List<AuthenticationRoleBinding> namespaceRoleBindings = authenticationInfo.getRoleBindings()
             .stream()
-            .filter(roleBinding -> roleBinding.getNamespace().equals(namespace))
+            .filter(roleBinding -> roleBinding.getNamespaces()
+                .stream()
+                .anyMatch(ns -> ns.equals(namespace)))
             .toList();
 
         if (namespaceRoleBindings.isEmpty()) {

--- a/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
+++ b/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
@@ -1,7 +1,6 @@
 package com.michelin.ns4kafka.security;
 
 import static com.michelin.ns4kafka.security.auth.JwtCustomClaimNames.ROLE_BINDINGS;
-import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
 
 import com.michelin.ns4kafka.model.RoleBinding;
 import com.michelin.ns4kafka.property.SecurityProperties;

--- a/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
+++ b/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
@@ -5,7 +5,6 @@ import static com.michelin.ns4kafka.security.auth.JwtCustomClaimNames.ROLE_BINDI
 import com.michelin.ns4kafka.model.RoleBinding;
 import com.michelin.ns4kafka.property.SecurityProperties;
 import com.michelin.ns4kafka.repository.NamespaceRepository;
-import com.michelin.ns4kafka.repository.RoleBindingRepository;
 import com.michelin.ns4kafka.security.auth.AuthenticationInfo;
 import com.michelin.ns4kafka.security.auth.AuthenticationRoleBinding;
 import com.michelin.ns4kafka.util.exception.ForbiddenNamespaceException;
@@ -43,9 +42,6 @@ public class ResourceBasedSecurityRule implements SecurityRule<HttpRequest<?>> {
 
     @Inject
     SecurityProperties securityProperties;
-
-    @Inject
-    RoleBindingRepository roleBindingRepository;
 
     @Inject
     NamespaceRepository namespaceRepository;

--- a/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
+++ b/src/main/java/com/michelin/ns4kafka/security/ResourceBasedSecurityRule.java
@@ -107,7 +107,7 @@ public class ResourceBasedSecurityRule implements SecurityRule<HttpRequest<?>> {
 
         AuthenticationInfo authenticationInfo = AuthenticationInfo.of(authentication);
 
-        // No role binding for the target namespace. User is targeting a namespace that he is not allowed to access
+        // No role binding for the target namespace: the user is not allowed to access the target namespace
         List<AuthenticationRoleBinding> namespaceRoleBindings = authenticationInfo.getRoleBindings()
             .stream()
             .filter(roleBinding -> roleBinding.getNamespaces()

--- a/src/main/java/com/michelin/ns4kafka/security/auth/AuthenticationRoleBinding.java
+++ b/src/main/java/com/michelin/ns4kafka/security/auth/AuthenticationRoleBinding.java
@@ -15,7 +15,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AuthenticationRoleBinding {
-    private String namespace;
+    private List<String> namespaces;
     private List<RoleBinding.Verb> verbs;
     private List<String> resourceTypes;
+
+    record VerbResourceTypes(List<RoleBinding.Verb> verbs, List<String> resourceTypes) {}
 }

--- a/src/main/java/com/michelin/ns4kafka/security/auth/AuthenticationRoleBinding.java
+++ b/src/main/java/com/michelin/ns4kafka/security/auth/AuthenticationRoleBinding.java
@@ -18,6 +18,4 @@ public class AuthenticationRoleBinding {
     private List<String> namespaces;
     private List<RoleBinding.Verb> verbs;
     private List<String> resourceTypes;
-
-    record VerbResourceTypes(List<RoleBinding.Verb> verbs, List<String> resourceTypes) {}
 }

--- a/src/main/java/com/michelin/ns4kafka/security/auth/AuthenticationService.java
+++ b/src/main/java/com/michelin/ns4kafka/security/auth/AuthenticationService.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 @Singleton
 public class AuthenticationService {
 
-
     @Inject
     ResourceBasedSecurityRule resourceBasedSecurityRule;
 

--- a/src/main/java/com/michelin/ns4kafka/security/auth/AuthenticationService.java
+++ b/src/main/java/com/michelin/ns4kafka/security/auth/AuthenticationService.java
@@ -14,6 +14,7 @@ import jakarta.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -50,10 +51,21 @@ public class AuthenticationService {
         return AuthenticationResponse.success(username, resourceBasedSecurityRule.computeRolesFromGroups(groups),
             Map.of(ROLE_BINDINGS, roleBindings
                 .stream()
-                .map(roleBinding -> AuthenticationRoleBinding.builder()
-                    .namespace(roleBinding.getMetadata().getNamespace())
-                    .verbs(new ArrayList<>(roleBinding.getSpec().getRole().getVerbs()))
-                    .resourceTypes(new ArrayList<>(roleBinding.getSpec().getRole().getResourceTypes()))
+                // group the namespaces by verbs + resourceTypes in a mapping
+                .collect(Collectors.groupingBy(roleBinding ->
+                    new AuthenticationRoleBinding.VerbResourceTypes(
+                        new ArrayList<>(roleBinding.getSpec().getRole().getVerbs()),
+                        new ArrayList<>(roleBinding.getSpec().getRole().getResourceTypes())
+                    ),
+                    Collectors.mapping(rb -> rb.getMetadata().getNamespace(), Collectors.toList())
+                ))
+                // build JWT with a list of namespaces for each combination of verbs + resourceTypes
+                .entrySet()
+                .stream()
+                .map(entry -> AuthenticationRoleBinding.builder()
+                    .namespaces(entry.getValue())
+                    .verbs(entry.getKey().verbs())
+                    .resourceTypes(entry.getKey().resourceTypes())
                     .build())
                 .toList()));
     }

--- a/src/main/java/com/michelin/ns4kafka/security/auth/AuthenticationService.java
+++ b/src/main/java/com/michelin/ns4kafka/security/auth/AuthenticationService.java
@@ -47,7 +47,9 @@ public class AuthenticationService {
             throw new AuthenticationException(new AuthenticationFailed("No namespace matches your groups"));
         }
 
-        return AuthenticationResponse.success(username, resourceBasedSecurityRule.computeRolesFromGroups(groups),
+        return AuthenticationResponse.success(
+            username,
+            resourceBasedSecurityRule.computeRolesFromGroups(groups),
             Map.of(ROLE_BINDINGS, roleBindings
                 .stream()
                 // group the namespaces by roles in a mapping
@@ -63,6 +65,7 @@ public class AuthenticationService {
                     .verbs(new ArrayList<>(entry.getKey().getVerbs()))
                     .resourceTypes(new ArrayList<>(entry.getKey().getResourceTypes()))
                     .build())
-                .toList()));
+                .toList())
+        );
     }
 }

--- a/src/test/java/com/michelin/ns4kafka/security/auth/AuthenticationInfoTest.java
+++ b/src/test/java/com/michelin/ns4kafka/security/auth/AuthenticationInfoTest.java
@@ -19,7 +19,7 @@ class AuthenticationInfoTest {
     @Test
     void shouldConvertFromMapRoleBindingsType() {
         Map<String, Object> attributes = new HashMap<>();
-        attributes.put(ROLE_BINDINGS, List.of(Map.of("namespace", "namespace",
+        attributes.put(ROLE_BINDINGS, List.of(Map.of("namespaces", List.of("namespace"),
             "verbs", List.of("GET"),
             "resourceTypes", List.of("topics"))));
         Authentication authentication = Authentication.build("name", List.of("role"), attributes);
@@ -28,14 +28,14 @@ class AuthenticationInfoTest {
 
         assertEquals("name", authenticationInfo.getName());
         assertEquals(List.of("role"), authenticationInfo.getRoles().stream().toList());
-        assertIterableEquals(List.of(new AuthenticationRoleBinding("namespace", List.of(GET), List.of("topics"))),
-            authenticationInfo.getRoleBindings().stream().toList());
+        assertIterableEquals(List.of(new AuthenticationRoleBinding(List.of("namespace"), List.of(GET),
+            List.of("topics"))), authenticationInfo.getRoleBindings().stream().toList());
     }
 
     @Test
     void shouldConvertFromAuthenticationRoleBindingsType() {
         Map<String, Object> attributes = new HashMap<>();
-        attributes.put(ROLE_BINDINGS, List.of(new AuthenticationRoleBinding("namespace", List.of(GET),
+        attributes.put(ROLE_BINDINGS, List.of(new AuthenticationRoleBinding(List.of("namespace"), List.of(GET),
             List.of("topics"))));
         Authentication authentication = Authentication.build("name", List.of("role"), attributes);
 
@@ -43,7 +43,7 @@ class AuthenticationInfoTest {
 
         assertEquals("name", authenticationInfo.getName());
         assertEquals(List.of("role"), authenticationInfo.getRoles().stream().toList());
-        assertIterableEquals(List.of(new AuthenticationRoleBinding("namespace", List.of(GET), List.of("topics"))),
-            authenticationInfo.getRoleBindings().stream().toList());
+        assertIterableEquals(List.of(new AuthenticationRoleBinding(List.of("namespace"), List.of(GET),
+            List.of("topics"))), authenticationInfo.getRoleBindings().stream().toList());
     }
 }

--- a/src/test/java/com/michelin/ns4kafka/security/auth/AuthenticationServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/security/auth/AuthenticationServiceTest.java
@@ -107,10 +107,10 @@ class AuthenticationServiceTest {
         assertTrue(response.getAuthentication().get().getRoles().contains(ResourceBasedSecurityRule.IS_ADMIN));
         assertTrue(response.getAuthentication().get().getAttributes()
             .containsKey("roleBindings"));
-        assertEquals("ns1",
+        assertEquals(List.of("ns1"),
             ((List<AuthenticationRoleBinding>) response.getAuthentication().get().getAttributes()
                 .get("roleBindings")).getFirst()
-                .getNamespace());
+                .getNamespaces());
         assertTrue(
             ((List<AuthenticationRoleBinding>) response.getAuthentication().get().getAttributes()
                 .get("roleBindings")).getFirst()
@@ -156,10 +156,10 @@ class AuthenticationServiceTest {
         assertTrue(response.getAuthentication().get().getRoles().isEmpty());
         assertTrue(response.getAuthentication().get().getAttributes()
             .containsKey("roleBindings"));
-        assertEquals("ns1",
+        assertEquals(List.of("ns1"),
             ((List<AuthenticationRoleBinding>) response.getAuthentication().get().getAttributes()
                 .get("roleBindings")).getFirst()
-                .getNamespace());
+                .getNamespaces());
         assertTrue(
             ((List<AuthenticationRoleBinding>) response.getAuthentication().get().getAttributes()
                 .get("roleBindings")).getFirst()

--- a/src/test/java/com/michelin/ns4kafka/security/auth/gitlab/GitlabAuthenticationProviderTest.java
+++ b/src/test/java/com/michelin/ns4kafka/security/auth/gitlab/GitlabAuthenticationProviderTest.java
@@ -52,7 +52,7 @@ class GitlabAuthenticationProviderTest {
             .thenReturn(Flux.fromIterable(groups));
 
         AuthenticationRoleBinding authenticationRoleBinding = AuthenticationRoleBinding.builder()
-            .namespace("namespace")
+            .namespaces(List.of("namespace"))
             .verbs(List.of(RoleBinding.Verb.GET))
             .resourceTypes(List.of("topics"))
             .build();
@@ -94,7 +94,7 @@ class GitlabAuthenticationProviderTest {
             .thenReturn(Flux.fromIterable(groups));
 
         AuthenticationRoleBinding authenticationRoleBinding = AuthenticationRoleBinding.builder()
-            .namespace("namespace")
+            .namespaces(List.of("namespace"))
             .verbs(List.of(RoleBinding.Verb.GET))
             .resourceTypes(List.of("topics"))
             .build();

--- a/src/test/java/com/michelin/ns4kafka/security/auth/ldap/LdapAuthenticationMapperTest.java
+++ b/src/test/java/com/michelin/ns4kafka/security/auth/ldap/LdapAuthenticationMapperTest.java
@@ -30,7 +30,7 @@ class LdapAuthenticationMapperTest {
     @SuppressWarnings("unchecked")
     void shouldMapAttributesToAuthenticationResponse() {
         AuthenticationRoleBinding authenticationRoleBinding = AuthenticationRoleBinding.builder()
-            .namespace("namespace")
+            .namespaces(List.of("namespace"))
             .verbs(List.of(RoleBinding.Verb.GET))
             .resourceTypes(List.of("topics"))
             .build();

--- a/src/test/java/com/michelin/ns4kafka/security/auth/local/LocalUserAuthenticationProviderTest.java
+++ b/src/test/java/com/michelin/ns4kafka/security/auth/local/LocalUserAuthenticationProviderTest.java
@@ -80,7 +80,7 @@ class LocalUserAuthenticationProviderTest {
                 .build()));
 
         AuthenticationRoleBinding authenticationRoleBinding = AuthenticationRoleBinding.builder()
-            .namespace("namespace")
+            .namespaces(List.of("namespace"))
             .verbs(List.of(RoleBinding.Verb.GET))
             .resourceTypes(List.of("topics"))
             .build();


### PR DESCRIPTION
This PR is about reducing the size of the JWT (`access_token`) generated by the `/login` endpoint, which is then used to authenticate in other endpoints. This would heavily reduce the risk of reaching the `http.client.max-content-length` limit in the future when the namespaces number increases, and have better performance in the logging process.

Example of the current JWT roleBindings format:

`"roleBindings": [
    {
      "namespace": "namespace1",
      "verbs": [
        "GET",
        "POST",
        "PUT",
        "DELETE"
      ],
      "resourceTypes": [
        "schemas",
        "schemas/config",
        "topics",
        "topics/delete-records"
      ]
    },
  {
      "namespace": "namespace2",
      "verbs": [
        "GET",
        "POST",
        "PUT",
        "DELETE"
      ],
      "resourceTypes": [
        "schemas",
        "schemas/config",
        "topics",
        "topics/delete-records"
      ]
    },
  {
      "namespace":  "namespace3",
      "verbs": [
        "GET",
        "POST",
        "PUT",
        "DELETE"
      ],
      "resourceTypes": [
        "schemas",
        "schemas/config",
        "topics",
        "topics/delete-records"
      ]
    }
]`

This PR changes the format of the JWT so the namespaces are grouped if they have the same `verbs` and `resourceTypes` fields. 
The previous example becomes:

`"roleBindings": [
    {
      "namespaces": [
        "namespace1",
        "namespace2",
        "namespace3"
      ],
      "verbs": [
        "GET",
        "POST",
        "PUT",
        "DELETE"
      ],
      "resourceTypes": [
        "schemas",
        "schemas/config",
        "topics",
        "topics/delete-records"
      ]
    }
]`

The **string** `namespace` field is replaced by a **list of string** `namespaces` field.

This PR is linked with [this kafkactl PR](https://github.com/michelin/kafkactl/pull/175).