### PR TITLE
Improve catalog information synchronisation with GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,18 +295,23 @@ The configuration will depend on the authentication method selected for your bro
 
 ### Stream Catalog
 
-For Confluent Cloud only, the Stream Catalog API is used to retrieve the list of topics with their tags and their description. Reminder that the `config.cluster.id` parameter from [managed cluster properties](#managed-clusters) must be set to use Confluent Cloud.
+For Confluent Cloud only, you can activate the synchronization of topic tags and description in ns4kafka with topic tags and description in Confluent Cloud.
 
-You can configure the page size of the response of the API using the following properties:
+The synchronization is done with the Confluent Stream Catalog GraphQL API if you have the appropriate Stream package on Confluent, otherwise with the Confluent Stream Catalog REST API.
+
+You can configure the synchronization using the following properties:
 
 ```yaml
 ns4kafka:
   confluent-cloud:
     stream-catalog:
       page-size: 500
+      sync-catalog: true
 ```
 
-The max page size is at 500 as described in the [Confluent Cloud documentation](https://docs.confluent.io/cloud/current/stream-governance/stream-catalog-rest-apis.html#list-all-topics).
+The max page size is used for the Stream Catalog API and is capped at 500 as described in the [Confluent Cloud documentation](https://docs.confluent.io/cloud/current/stream-governance/stream-catalog-rest-apis.html#list-all-topics).
+
+Reminder that the `config.cluster.id` parameter from [managed cluster properties](#managed-clusters) must be set to use Confluent Cloud.
 
 ### Managed Kafka Clusters
 

--- a/README.md
+++ b/README.md
@@ -295,9 +295,9 @@ The configuration will depend on the authentication method selected for your bro
 
 ### Stream Catalog
 
-For Confluent Cloud only, you can activate the synchronization of topic tags and description in ns4kafka with topic tags and description in Confluent Cloud.
+For Confluent Cloud only, topic tags and description can be synchronized with Ns4kafka.
 
-The synchronization is done with the Confluent Stream Catalog GraphQL API if you have the appropriate Stream package on Confluent, otherwise with the Confluent Stream Catalog REST API.
+The synchronization is done with the [Confluent Stream Catalog GraphQL API](https://docs.confluent.io/cloud/current/stream-governance/graphql-apis.html) if you have the appropriate Stream Governance package on Confluent, otherwise with the [Confluent Stream Catalog REST API](https://docs.confluent.io/cloud/current/stream-governance/stream-catalog-rest-apis.html#list-all-topics).
 
 You can configure the synchronization using the following properties:
 
@@ -309,7 +309,7 @@ ns4kafka:
       sync-catalog: true
 ```
 
-The max page size is used for the Stream Catalog API and is capped at 500 as described in the [Confluent Cloud documentation](https://docs.confluent.io/cloud/current/stream-governance/stream-catalog-rest-apis.html#list-all-topics).
+The page size is used for the Stream Catalog REST API and is capped at 500 as described in the [Confluent Cloud documentation](https://docs.confluent.io/cloud/current/stream-governance/stream-catalog-rest-apis.html#limits-on-topic-listings).
 
 Reminder that the `config.cluster.id` parameter from [managed cluster properties](#managed-clusters) must be set to use Confluent Cloud.
 

--- a/src/main/java/com/michelin/ns4kafka/service/client/schema/SchemaRegistryClient.java
+++ b/src/main/java/com/michelin/ns4kafka/service/client/schema/SchemaRegistryClient.java
@@ -20,6 +20,7 @@
 package com.michelin.ns4kafka.service.client.schema;
 
 import com.michelin.ns4kafka.property.ManagedClusterProperties;
+import com.michelin.ns4kafka.service.client.schema.entities.GraphQueryResponse;
 import com.michelin.ns4kafka.service.client.schema.entities.SchemaCompatibilityCheckResponse;
 import com.michelin.ns4kafka.service.client.schema.entities.SchemaCompatibilityRequest;
 import com.michelin.ns4kafka.service.client.schema.entities.SchemaCompatibilityResponse;
@@ -47,6 +48,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
@@ -283,11 +285,28 @@ public class SchemaRegistryClient {
     }
 
     /**
-     * Add a tag to a topic.
+     * List tags.
      *
      * @param kafkaCluster The Kafka cluster
-     * @param tagSpecs     Tags to add
-     * @return Information about added tags
+     * @return List of existing tags
+     */
+    public Mono<List<TagInfo>> listTags(String kafkaCluster) {
+        ManagedClusterProperties.SchemaRegistryProperties config = getSchemaRegistry(kafkaCluster);
+
+        HttpRequest<?> request = HttpRequest.GET(
+                URI.create(StringUtils.prependUri(config.getUrl(),
+                    "/catalog/v1/types/tagdefs")))
+            .basicAuth(config.getBasicAuthUsername(), config.getBasicAuthPassword());
+
+        return Mono.from(httpClient.retrieve(request, Argument.listOf(TagInfo.class)));
+    }
+
+    /**
+     * Add tags to a topic.
+     *
+     * @param kafkaCluster The Kafka cluster
+     * @param tagSpecs     The tags to add
+     * @return List of associated tags
      */
     public Mono<List<TagTopicInfo>> associateTags(String kafkaCluster, List<TagTopicInfo> tagSpecs) {
         ManagedClusterProperties.SchemaRegistryProperties config = getSchemaRegistry(kafkaCluster);
@@ -305,7 +324,7 @@ public class SchemaRegistryClient {
      *
      * @param tags         The list of tags to create
      * @param kafkaCluster The Kafka cluster
-     * @return Information about created tags
+     * @return List of created tags
      */
     public Mono<List<TagInfo>> createTags(String kafkaCluster, List<TagInfo> tags) {
         ManagedClusterProperties.SchemaRegistryProperties config = getSchemaRegistry(kafkaCluster);
@@ -319,10 +338,10 @@ public class SchemaRegistryClient {
     }
 
     /**
-     * Delete a tag to a topic.
+     * Delete a tag from a topic.
      *
      * @param kafkaCluster The Kafka cluster
-     * @param entityName   The topic's name
+     * @param entityName   The topic name
      * @param tagName      The tag to delete
      * @return The resume response
      */
@@ -338,12 +357,12 @@ public class SchemaRegistryClient {
     }
 
     /**
-     * List topics with catalog info, including tag & description.
+     * List topics with catalog info including tags & description, using Stream Catalog API.
      *
      * @param kafkaCluster The Kafka cluster
-     * @return A list of description
+     * @return The topics list with their catalog information
      */
-    public Mono<TopicListResponse> getTopicWithCatalogInfo(String kafkaCluster, int limit, int offset) {
+    public Mono<TopicListResponse> getTopicsWithStreamCatalog(String kafkaCluster, int limit, int offset) {
         ManagedClusterProperties.SchemaRegistryProperties config = getSchemaRegistry(kafkaCluster);
 
         HttpRequest<?> request = HttpRequest.GET(
@@ -355,10 +374,52 @@ public class SchemaRegistryClient {
     }
 
     /**
+     * Query Stream Catalog information, using GraphQL.
+     *
+     * @param kafkaCluster The Kafka cluster
+     * @param query        The GraphQL query
+     * @return The GraphQL response
+     */
+    public Mono<GraphQueryResponse> queryWithGraphQl(String kafkaCluster, String query) {
+        ManagedClusterProperties.SchemaRegistryProperties config = getSchemaRegistry(kafkaCluster);
+
+        HttpRequest<?> request = HttpRequest.POST(
+                URI.create(StringUtils.prependUri(config.getUrl(),
+                    "/catalog/graphql")),
+                Map.of("query", query))
+            .basicAuth(config.getBasicAuthUsername(), config.getBasicAuthPassword());
+
+        return Mono.from(httpClient.retrieve(request, GraphQueryResponse.class));
+    }
+
+    /**
+     * List topics with tags, using GraphQL.
+     *
+     * @param kafkaCluster The Kafka cluster
+     * @return The GraphQL response containing the topics list with their tags
+     */
+    public Mono<GraphQueryResponse> getTopicsWithTagsWithGraphQl(String kafkaCluster, List<String> tagsNames) {
+        String query = "query { kafka_topic(tags: [" + String.join(",", tagsNames) + "]) { nameLower tags } }";
+
+        return queryWithGraphQl(kafkaCluster, query);
+    }
+
+    /**
+     * List topics with description, using GraphQL.
+     *
+     * @param kafkaCluster The Kafka cluster
+     * @return The GraphQL query response containing the topics list with their descriptions
+     */
+    public Mono<GraphQueryResponse> getTopicsWithDescriptionWithGraphQl(String kafkaCluster) {
+        String query = "query { kafka_topic(where: {description: {_gte: null}}) { nameLower description } }";
+        return queryWithGraphQl(kafkaCluster, query);
+    }
+
+    /**
      * Update a topic description.
      *
      * @param kafkaCluster The Kafka cluster
-     * @param body         The body passed to the request
+     * @param body         The body given to the request
      * @return Information about description
      */
     public Mono<HttpResponse<TopicDescriptionUpdateResponse>> updateDescription(String kafkaCluster,

--- a/src/main/java/com/michelin/ns4kafka/service/client/schema/SchemaRegistryClient.java
+++ b/src/main/java/com/michelin/ns4kafka/service/client/schema/SchemaRegistryClient.java
@@ -380,7 +380,7 @@ public class SchemaRegistryClient {
      * @param query        The GraphQL query
      * @return The GraphQL response
      */
-    public Mono<GraphQueryResponse> queryWithGraphQl(String kafkaCluster, String query) {
+    private Mono<GraphQueryResponse> queryWithGraphQl(String kafkaCluster, String query) {
         ManagedClusterProperties.SchemaRegistryProperties config = getSchemaRegistry(kafkaCluster);
 
         HttpRequest<?> request = HttpRequest.POST(

--- a/src/main/java/com/michelin/ns4kafka/service/client/schema/entities/GraphQueryData.java
+++ b/src/main/java/com/michelin/ns4kafka/service/client/schema/entities/GraphQueryData.java
@@ -17,29 +17,17 @@
  * under the License.
  */
 
-package com.michelin.ns4kafka.property;
+package com.michelin.ns4kafka.service.client.schema.entities;
 
-import io.micronaut.context.annotation.ConfigurationProperties;
-import lombok.Getter;
-import lombok.Setter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Builder;
 
 /**
- * Confluent Cloud properties.
+ * GraphQL query data.
+ *
+ * @param kafkaTopic the list of queried kafka topics
  */
-@Getter
-@Setter
-@ConfigurationProperties("ns4kafka.confluent-cloud")
-public class ConfluentCloudProperties {
-    private StreamCatalogProperties streamCatalog = new StreamCatalogProperties();
-
-    /**
-     * Stream Catalog properties.
-     */
-    @Getter
-    @Setter
-    @ConfigurationProperties("stream-catalog")
-    public static class StreamCatalogProperties {
-        private int pageSize = 500;
-        private boolean syncCatalog;
-    }
+@Builder
+public record GraphQueryData(@JsonProperty("kafka_topic") List<GraphQueryTopic> kafkaTopic) {
 }

--- a/src/main/java/com/michelin/ns4kafka/service/client/schema/entities/GraphQueryResponse.java
+++ b/src/main/java/com/michelin/ns4kafka/service/client/schema/entities/GraphQueryResponse.java
@@ -17,29 +17,15 @@
  * under the License.
  */
 
-package com.michelin.ns4kafka.property;
+package com.michelin.ns4kafka.service.client.schema.entities;
 
-import io.micronaut.context.annotation.ConfigurationProperties;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Builder;
 
 /**
- * Confluent Cloud properties.
+ * GraphQL query response.
+ *
+ * @param data the response data
  */
-@Getter
-@Setter
-@ConfigurationProperties("ns4kafka.confluent-cloud")
-public class ConfluentCloudProperties {
-    private StreamCatalogProperties streamCatalog = new StreamCatalogProperties();
-
-    /**
-     * Stream Catalog properties.
-     */
-    @Getter
-    @Setter
-    @ConfigurationProperties("stream-catalog")
-    public static class StreamCatalogProperties {
-        private int pageSize = 500;
-        private boolean syncCatalog;
-    }
+@Builder
+public record GraphQueryResponse(GraphQueryData data) {
 }

--- a/src/main/java/com/michelin/ns4kafka/service/client/schema/entities/GraphQueryTopic.java
+++ b/src/main/java/com/michelin/ns4kafka/service/client/schema/entities/GraphQueryTopic.java
@@ -17,29 +17,19 @@
  * under the License.
  */
 
-package com.michelin.ns4kafka.property;
+package com.michelin.ns4kafka.service.client.schema.entities;
 
-import io.micronaut.context.annotation.ConfigurationProperties;
-import lombok.Getter;
-import lombok.Setter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Builder;
 
 /**
- * Confluent Cloud properties.
+ * GraphQL query kafka topic.
+ *
+ * @param name        the topic name
+ * @param description the topic description
+ * @param tags        the topic tags
  */
-@Getter
-@Setter
-@ConfigurationProperties("ns4kafka.confluent-cloud")
-public class ConfluentCloudProperties {
-    private StreamCatalogProperties streamCatalog = new StreamCatalogProperties();
-
-    /**
-     * Stream Catalog properties.
-     */
-    @Getter
-    @Setter
-    @ConfigurationProperties("stream-catalog")
-    public static class StreamCatalogProperties {
-        private int pageSize = 500;
-        private boolean syncCatalog;
-    }
+@Builder
+public record GraphQueryTopic(@JsonProperty("nameLower") String name, String description, List<String> tags) {
 }

--- a/src/main/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutor.java
+++ b/src/main/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutor.java
@@ -316,19 +316,19 @@ public class TopicAsyncExecutor {
         if (confluentCloudProperties.getStreamCatalog().isSyncCatalog()
             && managedClusterProperties.isConfluentCloud()) {
             try {
-                enrichWithCatalogInfoWithGraphQl(topics);
+                enrichWithGraphQlCatalogInfo(topics);
             } catch (Exception e) {
-                enrichWithCatalogInfoWithStreamCatalog(topics);
+                enrichWithRestCatalogInfo(topics);
             }
         }
     }
 
     /**
-     * Enrich topics with Confluent catalog information, using Confluent GraphQL API.
+     * Enrich topics with Confluent catalog information, using Confluent Stream Catalog GraphQL API.
      *
      * @param topics Topics to enrich
      */
-    public void enrichWithCatalogInfoWithGraphQl(Map<String, Topic> topics) {
+    public void enrichWithGraphQlCatalogInfo(Map<String, Topic> topics) {
         schemaRegistryClient.getTopicsWithDescriptionWithGraphQl(managedClusterProperties.getName())
             .subscribe(response -> {
                 if (response.data() != null && response.data().kafkaTopic() != null) {
@@ -361,11 +361,11 @@ public class TopicAsyncExecutor {
     }
 
     /**
-     * Enrich topics with Confluent catalog information, using Confluent Stream Catalog API.
+     * Enrich topics with Confluent catalog information, using Confluent Stream Catalog REST API.
      *
      * @param topics Topics to enrich
      */
-    public void enrichWithCatalogInfoWithStreamCatalog(Map<String, Topic> topics) {
+    public void enrichWithRestCatalogInfo(Map<String, Topic> topics) {
         // getting topics by managing offset & limit
         TopicListResponse topicListResponse;
         int offset = 0;

--- a/src/main/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutor.java
+++ b/src/main/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutor.java
@@ -26,6 +26,7 @@ import com.michelin.ns4kafka.property.ManagedClusterProperties;
 import com.michelin.ns4kafka.repository.TopicRepository;
 import com.michelin.ns4kafka.repository.kafka.KafkaStoreException;
 import com.michelin.ns4kafka.service.client.schema.SchemaRegistryClient;
+import com.michelin.ns4kafka.service.client.schema.entities.GraphQueryResponse;
 import com.michelin.ns4kafka.service.client.schema.entities.TagInfo;
 import com.michelin.ns4kafka.service.client.schema.entities.TagTopicInfo;
 import com.michelin.ns4kafka.service.client.schema.entities.TopicDescriptionUpdateAttributes;
@@ -64,6 +65,7 @@ import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.admin.TopicListing;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
+import reactor.core.publisher.Mono;
 
 /**
  * Topic executor.
@@ -155,16 +157,27 @@ public class TopicAsyncExecutor {
 
             createTopics(createTopics);
             alterTopics(updateTopics, checkTopics);
+            alterCatalogInfo(checkTopics, brokerTopics);
 
-            if (managedClusterProperties.isConfluentCloud()) {
-                alterTags(checkTopics, brokerTopics);
-                alterDescriptions(checkTopics, brokerTopics);
-            }
         } catch (ExecutionException | TimeoutException | CancellationException | KafkaStoreException e) {
             log.error("An error occurred during the topic synchronization", e);
         } catch (InterruptedException e) {
             log.error("Thread interrupted during the topic synchronization", e);
             Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Alter catalog info.
+     *
+     * @param checkTopics    Topics from ns4kafka
+     * @param brokerTopics   Topics from broker
+     */
+    public void alterCatalogInfo(List<Topic> checkTopics, Map<String, Topic> brokerTopics) {
+        if (confluentCloudProperties.getStreamCatalog().isSyncCatalog()
+            && managedClusterProperties.isConfluentCloud()) {
+            alterTags(checkTopics, brokerTopics);
+            alterDescriptions(checkTopics, brokerTopics);
         }
     }
 
@@ -294,38 +307,89 @@ public class TopicAsyncExecutor {
     }
 
     /**
-     * Enrich topics with confluent description.
+     * Enrich topics with Confluent catalog info.
      *
-     * @param topics Topics to complete
+     * @param topics Topics to enrich
      */
 
     public void enrichWithCatalogInfo(Map<String, Topic> topics) {
-        if (managedClusterProperties.isConfluentCloud()) {
-            TopicListResponse topicListResponse;
-
-            // getting list of topics by managing offset & limit
-            int offset = 0;
-            int limit = confluentCloudProperties.getStreamCatalog().getPageSize();
-            do {
-                topicListResponse = schemaRegistryClient.getTopicWithCatalogInfo(
-                    managedClusterProperties.getName(), limit, offset).block();
-                if (topicListResponse == null) {
-                    break;
-                }
-                topicListResponse.entities()
-                    .stream()
-                    .filter(topicEntity -> (topicEntity.attributes().description() != null
-                        || !topicEntity.classificationNames().isEmpty())
-                        && topics.containsKey(topicEntity.attributes().name()))
-                    .forEach(topicEntity -> {
-                        topics.get(topicEntity.attributes().name()).getSpec()
-                            .setTags(topicEntity.classificationNames());
-                        topics.get(topicEntity.attributes().name()).getSpec()
-                            .setDescription(topicEntity.attributes().description());
-                    });
-                offset += limit;
-            } while (!topicListResponse.entities().isEmpty());
+        if (confluentCloudProperties.getStreamCatalog().isSyncCatalog()
+            && managedClusterProperties.isConfluentCloud()) {
+            try {
+                enrichWithCatalogInfoWithGraphQl(topics);
+            } catch (Exception e) {
+                enrichWithCatalogInfoWithStreamCatalog(topics);
+            }
         }
+    }
+
+    /**
+     * Enrich topics with Confluent catalog information, using Confluent GraphQL API.
+     *
+     * @param topics Topics to enrich
+     */
+    public void enrichWithCatalogInfoWithGraphQl(Map<String, Topic> topics) {
+        schemaRegistryClient.getTopicsWithDescriptionWithGraphQl(managedClusterProperties.getName())
+            .subscribe(response -> {
+                if (response.data() != null && response.data().kafkaTopic() != null) {
+                    response
+                        .data()
+                        .kafkaTopic()
+                        .forEach(describedTopic ->
+                            topics.get(describedTopic.name()).getSpec().setDescription(describedTopic.description()));
+                }
+            });
+
+        schemaRegistryClient.listTags(managedClusterProperties.getName())
+            .flatMap(tagsList ->
+                tagsList.isEmpty() ? Mono.just(GraphQueryResponse.builder().data(null).build())
+                    : schemaRegistryClient.getTopicsWithTagsWithGraphQl(
+                        managedClusterProperties.getName(),
+                        tagsList
+                            .stream()
+                            .map(tagInfo -> "\"" + tagInfo.name() + "\"")
+                            .toList()))
+            .subscribe(response -> {
+                if (response.data() != null && response.data().kafkaTopic() != null) {
+                    response
+                        .data()
+                        .kafkaTopic()
+                        .forEach(taggedTopic ->
+                            topics.get(taggedTopic.name()).getSpec().setTags(taggedTopic.tags()));
+                }
+            });
+    }
+
+    /**
+     * Enrich topics with Confluent catalog information, using Confluent Stream Catalog API.
+     *
+     * @param topics Topics to enrich
+     */
+    public void enrichWithCatalogInfoWithStreamCatalog(Map<String, Topic> topics) {
+        // getting topics by managing offset & limit
+        TopicListResponse topicListResponse;
+        int offset = 0;
+        int limit = confluentCloudProperties.getStreamCatalog().getPageSize();
+
+        do {
+            topicListResponse = schemaRegistryClient.getTopicsWithStreamCatalog(
+                managedClusterProperties.getName(), limit, offset).block();
+            if (topicListResponse == null) {
+                break;
+            }
+            topicListResponse.entities()
+                .stream()
+                .filter(topicEntity -> (topicEntity.attributes().description() != null
+                    || !topicEntity.classificationNames().isEmpty())
+                    && topics.containsKey(topicEntity.attributes().name()))
+                .forEach(topicEntity -> {
+                    topics.get(topicEntity.attributes().name()).getSpec()
+                        .setTags(topicEntity.classificationNames());
+                    topics.get(topicEntity.attributes().name()).getSpec()
+                        .setDescription(topicEntity.attributes().description());
+                });
+            offset += limit;
+        } while (!topicListResponse.entities().isEmpty());
     }
 
     /**

--- a/src/test/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutorTest.java
@@ -651,7 +651,7 @@ class TopicAsyncExecutorTest {
     }
 
     @Test
-    void shouldEnrichWithCatalogInfoWithStreamCatalogAfterExceptionInGraphQl() {
+    void shouldEnrichWithRestCatalogInfoAfterExceptionInGraphQl() {
         when(confluentCloudProperties.getStreamCatalog()).thenReturn(streamCatalogProperties);
         when(streamCatalogProperties.isSyncCatalog()).thenReturn(true);
         when(managedClusterProperties.isConfluentCloud()).thenReturn(true);
@@ -790,7 +790,7 @@ class TopicAsyncExecutorTest {
                 .spec(Topic.TopicSpec.builder().build())
                 .build());
 
-        topicAsyncExecutor.enrichWithCatalogInfoWithGraphQl(brokerTopics);
+        topicAsyncExecutor.enrichWithGraphQlCatalogInfo(brokerTopics);
 
         assertEquals(brokerTopics.get(TOPIC_NAME).getSpec(),
             Topic.TopicSpec.builder()
@@ -831,7 +831,7 @@ class TopicAsyncExecutorTest {
                 .spec(Topic.TopicSpec.builder().build())
                 .build());
 
-        topicAsyncExecutor.enrichWithCatalogInfoWithGraphQl(brokerTopics);
+        topicAsyncExecutor.enrichWithGraphQlCatalogInfo(brokerTopics);
 
         assertNull(brokerTopics.get(TOPIC_NAME).getSpec().getDescription());
         assertNull(brokerTopics.get(TOPIC_NAME2).getSpec().getDescription());
@@ -862,7 +862,7 @@ class TopicAsyncExecutorTest {
                 .spec(Topic.TopicSpec.builder().build())
                 .build());
 
-        topicAsyncExecutor.enrichWithCatalogInfoWithGraphQl(brokerTopics);
+        topicAsyncExecutor.enrichWithGraphQlCatalogInfo(brokerTopics);
 
         assertNull(brokerTopics.get(TOPIC_NAME).getSpec().getDescription());
         assertTrue(brokerTopics.get(TOPIC_NAME).getSpec().getTags().isEmpty());
@@ -897,7 +897,7 @@ class TopicAsyncExecutorTest {
                 .spec(Topic.TopicSpec.builder().build())
                 .build());
 
-        topicAsyncExecutor.enrichWithCatalogInfoWithGraphQl(brokerTopics);
+        topicAsyncExecutor.enrichWithGraphQlCatalogInfo(brokerTopics);
 
         assertNull(brokerTopics.get(TOPIC_NAME).getSpec().getDescription());
         assertTrue(brokerTopics.get(TOPIC_NAME).getSpec().getTags().isEmpty());
@@ -928,7 +928,7 @@ class TopicAsyncExecutorTest {
                 .spec(Topic.TopicSpec.builder().build())
                 .build());
 
-        topicAsyncExecutor.enrichWithCatalogInfoWithGraphQl(brokerTopics);
+        topicAsyncExecutor.enrichWithGraphQlCatalogInfo(brokerTopics);
 
         assertNull(brokerTopics.get(TOPIC_NAME).getSpec().getDescription());
         assertTrue(brokerTopics.get(TOPIC_NAME).getSpec().getTags().isEmpty());
@@ -1005,7 +1005,7 @@ class TopicAsyncExecutorTest {
                 .spec(Topic.TopicSpec.builder().build())
                 .build());
 
-        topicAsyncExecutor.enrichWithCatalogInfoWithStreamCatalog(brokerTopics);
+        topicAsyncExecutor.enrichWithRestCatalogInfo(brokerTopics);
 
         assertNull(brokerTopics.get(TOPIC_NAME).getSpec().getDescription());
         assertTrue(brokerTopics.get(TOPIC_NAME).getSpec().getTags().isEmpty());
@@ -1018,7 +1018,7 @@ class TopicAsyncExecutorTest {
     }
 
     @Test
-    void shouldEnrichWithCatalogInfoWithStreamCatalogWhenResponseIsNull() {
+    void shouldEnrichWithRestCatalogInfoWhenResponseIsNull() {
         when(managedClusterProperties.getName()).thenReturn(LOCAL_CLUSTER);
         when(confluentCloudProperties.getStreamCatalog()).thenReturn(streamCatalogProperties);
         when(streamCatalogProperties.getPageSize()).thenReturn(500);
@@ -1040,7 +1040,7 @@ class TopicAsyncExecutorTest {
                 .spec(Topic.TopicSpec.builder().build())
                 .build());
 
-        topicAsyncExecutor.enrichWithCatalogInfoWithStreamCatalog(brokerTopics);
+        topicAsyncExecutor.enrichWithRestCatalogInfo(brokerTopics);
 
         assertNull(brokerTopics.get(TOPIC_NAME).getSpec().getDescription());
         assertNull(brokerTopics.get(TOPIC_NAME2).getSpec().getDescription());

--- a/src/test/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/executor/TopicAsyncExecutorTest.java
@@ -598,7 +598,7 @@ class TopicAsyncExecutorTest {
     }
 
     @Test
-    void shouldEnrichWithCatalogInfoWithGraphQl() {
+    void shouldEnrichWithGraphQlCatalogInfo() {
         when(confluentCloudProperties.getStreamCatalog()).thenReturn(streamCatalogProperties);
         when(streamCatalogProperties.isSyncCatalog()).thenReturn(true);
         when(managedClusterProperties.isConfluentCloud()).thenReturn(true);
@@ -734,7 +734,7 @@ class TopicAsyncExecutorTest {
     }
 
     @Test
-    void shouldEnrichMultipleTopicsWithCatalogInfoWithGraphQl() {
+    void shouldEnrichMultipleTopicsWithGraphQlCatalogInfo() {
         when(managedClusterProperties.getName()).thenReturn(LOCAL_CLUSTER);
 
         List<TagInfo> tags = List.of(TagInfo.builder().name(TAG1).build());
@@ -805,7 +805,7 @@ class TopicAsyncExecutorTest {
     }
 
     @Test
-    void shouldNotEnrichWithCatalogInfoWithGraphQlWhenResponseIsNull() {
+    void shouldNotEnrichWithGraphQlCatalogInfoWhenResponseIsNull() {
         List<TagInfo> tags = List.of(TagInfo.builder().name(TAG1).build());
 
         when(managedClusterProperties.getName()).thenReturn(LOCAL_CLUSTER);
@@ -935,7 +935,7 @@ class TopicAsyncExecutorTest {
     }
 
     @Test
-    void shouldEnrichMultipleTopicsWithCatalogInfoWithStreamCatalog() {
+    void shouldEnrichMultipleTopicsWithRestCatalogInfo() {
         when(managedClusterProperties.getName()).thenReturn(LOCAL_CLUSTER);
         when(confluentCloudProperties.getStreamCatalog()).thenReturn(streamCatalogProperties);
         when(streamCatalogProperties.getPageSize()).thenReturn(500);


### PR DESCRIPTION
**1. Context**

- Currently, we have the possibility to add tags and description to a topic and ns4kafka synchronizes these information with **Confluent Cloud** catalog information (tags & description). This synchronisation is performed with the Stream Catalog REST API ([Stream Catalog documentation](https://docs.confluent.io/cloud/current/stream-governance/stream-catalog-rest-apis.html)).

- However, this API is not suited for the synchronisation because of the **500 topics limit** per call, and the fact that **there is no filter** allowing to **query only topics with a description** (though it is possible to query only topics with at least one tag). These drawbacks lead to having to query all the cluster topics 500 per 500 in order to perform the synchronization, which is quite bad for performance.

**2. Proposed implementation**
This PR adds GraphQL API calls to query the topic lists with their tags and description. This API overcomes the two previous problems: it is possible to query the list of topics with a description, and query the list of topics with at least one tag, without pagination.

This API still has drawbacks:
- it is only usable with the advanced Stream Governance Package on Confluent Cloud, which is the non-free package at 1$/hour: so we first try to use GraphQL API, and if it fails, we use the old Stream Catalog REST API to get the topics.
- In order to query topics with at least one tag, all the existing tags need to be filled in the GraphQL query, so another API call to Stream Catalog shall be made to get the tags list.
- I didn't find a way to query the list of topics with a description **OR** with at least one tag. I had to split the call: so one GraphQL API call to get the topics with a description, another one to get the topics with at least one tag. If you want to challenge it, you can try the GraphQL API (doc: https://docs.confluent.io/cloud/current/stream-governance/graphql-apis.html#definition-kafka_topic)

**3. Other**
- I added a `sync-catalog` property which must be set to `true` in order to allow the synchronization of catalog information in Confluent Cloud. It is set at `false` by default.

