### PR TITLE
Add new ContainsList validator

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
+++ b/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
@@ -92,12 +92,12 @@ public class FormatErrorUtils {
      * @return the error message
      */
     public static String invalidValueMustBeOneOf(
-        String invalidFieldName, String invalidFieldValue, String allowedFieldTypes) {
+            String invalidFieldName, String invalidFieldValue, String allowedFieldTypes) {
         return String.format(
-            INVALID_FIELD,
-            invalidFieldValue,
-            invalidFieldName,
-            String.format("value must be one of \"%s\"", allowedFieldTypes));
+                INVALID_FIELD,
+                invalidFieldValue,
+                invalidFieldName,
+                String.format("value must be one of \"%s\"", allowedFieldTypes));
     }
 
     /**
@@ -442,18 +442,19 @@ public class FormatErrorUtils {
 
     /**
      * Invalid field must contain values
+     *
      * @param invalidFieldName the invalid field name
      * @param invalidFieldValue the invalid field value
      * @param mandatoryFieldValues the mandatory field values
      * @return the error message
      */
     public static String invalidFieldValidationContains(
-        String invalidFieldName, String invalidFieldValue, String mandatoryFieldValues) {
+            String invalidFieldName, String invalidFieldValue, String mandatoryFieldValues) {
         return String.format(
-            INVALID_FIELD,
-            invalidFieldValue,
-            invalidFieldName,
-            String.format("value must contain \"%s\"", mandatoryFieldValues));
+                INVALID_FIELD,
+                invalidFieldValue,
+                invalidFieldName,
+                String.format("value must contain \"%s\"", mandatoryFieldValues));
     }
 
     /**

--- a/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
+++ b/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
@@ -92,12 +92,12 @@ public class FormatErrorUtils {
      * @return the error message
      */
     public static String invalidValueMustBeOneOf(
-            String invalidFieldName, String invalidFieldValue, String allowedFieldTypes) {
+        String invalidFieldName, String invalidFieldValue, String allowedFieldTypes) {
         return String.format(
-                INVALID_FIELD,
-                invalidFieldValue,
-                invalidFieldName,
-                String.format("value must be one of \"%s\"", allowedFieldTypes));
+            INVALID_FIELD,
+            invalidFieldValue,
+            invalidFieldName,
+            String.format("value must be one of \"%s\"", allowedFieldTypes));
     }
 
     /**
@@ -438,6 +438,22 @@ public class FormatErrorUtils {
     public static String invalidFieldValidationOneOf(
             String invalidFieldName, String invalidFieldValue, String allowedValues) {
         return invalidValueMustBeOneOf(invalidFieldName, invalidFieldValue, allowedValues);
+    }
+
+    /**
+     * Invalid field must contain values
+     * @param invalidFieldName the invalid field name
+     * @param invalidFieldValue the invalid field value
+     * @param mandatoryFieldValues the mandatory field values
+     * @return the error message
+     */
+    public static String invalidFieldValidationContains(
+        String invalidFieldName, String invalidFieldValue, String mandatoryFieldValues) {
+        return String.format(
+            INVALID_FIELD,
+            invalidFieldValue,
+            invalidFieldName,
+            String.format("value must contain \"%s\"", mandatoryFieldValues));
     }
 
     /**

--- a/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
@@ -332,7 +332,7 @@ public abstract class ResourceValidator {
 
             if (!new HashSet<>(values).containsAll(mandatoryStrings)) {
                 throw new FieldValidationException(
-                    invalidFieldValidationContains(name, value.toString(), String.join(",", mandatoryStrings)));
+                        invalidFieldValidationContains(name, value.toString(), String.join(",", mandatoryStrings)));
             }
         }
     }

--- a/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
@@ -175,4 +175,29 @@ class ResourceValidatorTest {
         assertDoesNotThrow(() -> original.ensureValid("k", "b,c"));
         assertDoesNotThrow(() -> original.ensureValid("k", "c,b,a"));
     }
+
+    @Test
+    void shouldValidateContainsList() {
+        ResourceValidator.Validator original = ResourceValidator.ContainsList.contains("a", "b", "c");
+
+        assertThrows(FieldValidationException.class, () -> original.ensureValid("k", null));
+        assertThrows(FieldValidationException.class, () -> original.ensureValid("k", ""));
+        assertThrows(FieldValidationException.class, () -> original.ensureValid("k", "A"));
+        assertThrows(FieldValidationException.class, () -> original.ensureValid("k", "d"));
+        assertThrows(FieldValidationException.class, () -> original.ensureValid("k", "1"));
+        assertThrows(FieldValidationException.class, () -> original.ensureValid("k", "A,B"));
+        assertThrows(FieldValidationException.class, () -> original.ensureValid("k", "a,b"));
+        assertThrows(FieldValidationException.class, () -> original.ensureValid("k", "a,c"));
+        assertThrows(FieldValidationException.class, () -> original.ensureValid("k", "b,c"));
+        assertThrows(FieldValidationException.class, () -> original.ensureValid("k", "c,a"));
+        assertThrows(FieldValidationException.class, () -> original.ensureValid("k", "c,b"));
+        assertDoesNotThrow(() -> original.ensureValid("k", "a,b,c"));
+        assertDoesNotThrow(() -> original.ensureValid("k", "a,c,b"));
+        assertDoesNotThrow(() -> original.ensureValid("k", "b,c,a"));
+        assertDoesNotThrow(() -> original.ensureValid("k", "c,a,b"));
+        assertDoesNotThrow(() -> original.ensureValid("k", "c,b,a"));
+        assertDoesNotThrow(() -> original.ensureValid("k", "a,b,c,d"));
+        assertDoesNotThrow(() -> original.ensureValid("k", "d,a,b,c"));
+        assertDoesNotThrow(() -> original.ensureValid("k", "a,d,b,c"));
+    }
 }


### PR DESCRIPTION
This PR adds a new validator "ContainsList". It checks that a field contains all the items from a list.
It helps in our case to prevent users from creating connectors on some topics by adding this validator to the topic.blacklist field.

```yaml
  connectValidator:
    validationConstraints:
      topic.blacklist:
        validation-type: ContainsList
        mandatoryStrings:
            - ns1.topic1
            - ns1.topic2
```

Expected value 

```yaml
    topic.blacklist: ns1.topic1,ns1.topic2,ns1.otherTopicToBlacklist
```