### PR TITLE
Add the possibility to import specific topics

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controller/topic/TopicController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/topic/TopicController.java
@@ -245,17 +245,21 @@ public class TopicController extends NamespacedResourceController {
      * Import unsynchronized topics.
      *
      * @param namespace The namespace
+     * @param name The name parameter
      * @param dryrun Is dry run mode or not?
      * @return The list of imported topics
      * @throws ExecutionException Any execution exception
      * @throws InterruptedException Any interrupted exception
      * @throws TimeoutException Any timeout exception
      */
-    @Post("/_/import{?dryrun}")
-    public List<Topic> importResources(String namespace, @QueryValue(defaultValue = "false") boolean dryrun)
+    @Post("/_/import")
+    public List<Topic> importResources(
+            String namespace,
+            @QueryValue(defaultValue = "*") String name,
+            @QueryValue(defaultValue = "false") boolean dryrun)
             throws ExecutionException, InterruptedException, TimeoutException {
         Namespace ns = getNamespace(namespace);
-        List<Topic> unsynchronizedTopics = topicService.listUnsynchronizedTopics(ns);
+        List<Topic> unsynchronizedTopics = topicService.listUnsynchronizedTopicsByWildcardName(ns, name);
 
         if (dryrun) {
             return unsynchronizedTopics;

--- a/src/test/java/com/michelin/ns4kafka/controller/TopicControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/TopicControllerTest.java
@@ -19,6 +19,7 @@
 package com.michelin.ns4kafka.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -715,7 +716,7 @@ class TopicControllerTest {
     }
 
     @Test
-    void shouldImportTopic() throws InterruptedException, ExecutionException, TimeoutException {
+    void shouldImportTopics() throws InterruptedException, ExecutionException, TimeoutException {
         Namespace ns = Namespace.builder()
                 .metadata(Metadata.builder().name("test").cluster("local").build())
                 .spec(NamespaceSpec.builder()
@@ -744,10 +745,10 @@ class TopicControllerTest {
                 .build();
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
-        when(topicService.listUnsynchronizedTopics(ns)).thenReturn(List.of(topic1, topic2));
+        when(topicService.listUnsynchronizedTopicsByWildcardName(ns, "*")).thenReturn(List.of(topic1, topic2));
         doNothing().when(topicService).importTopics(any(), any());
 
-        List<Topic> actual = topicController.importResources("test", false);
+        List<Topic> actual = topicController.importResources("test", "*", false);
 
         assertTrue(actual.stream()
                 .anyMatch(t -> t.getMetadata().getName().equals("test.topic1")
@@ -798,13 +799,63 @@ class TopicControllerTest {
                 .build();
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
-        when(topicService.listUnsynchronizedTopics(ns)).thenReturn(List.of(topic1, topic2));
+        when(topicService.listUnsynchronizedTopicsByWildcardName(ns, "*")).thenReturn(List.of(topic1, topic2));
 
-        List<Topic> actual = topicController.importResources("test", true);
+        List<Topic> actual = topicController.importResources("test", "*", true);
 
         assertTrue(actual.stream().anyMatch(t -> t.getMetadata().getName().equals("test.topic1")));
 
         assertTrue(actual.stream().anyMatch(t -> t.getMetadata().getName().equals("test.topic2")));
+    }
+
+    @Test
+    void shouldImportTopicWithNameParameter() throws InterruptedException, ExecutionException, TimeoutException {
+        Namespace ns = Namespace.builder()
+                .metadata(Metadata.builder().name("test").cluster("local").build())
+                .spec(NamespaceSpec.builder()
+                        .topicValidator(TopicValidator.makeDefault())
+                        .build())
+                .build();
+
+        Topic topic1 = Topic.builder()
+                .metadata(Metadata.builder().name("test.topic1").build())
+                .spec(Topic.TopicSpec.builder()
+                        .replicationFactor(3)
+                        .partitions(3)
+                        .configs(
+                                Map.of("cleanup.policy", "delete", "min.insync.replicas", "2", "retention.ms", "60000"))
+                        .build())
+                .build();
+
+        Topic topic2 = Topic.builder()
+                .metadata(Metadata.builder().name("test.topic2").build())
+                .spec(Topic.TopicSpec.builder()
+                        .replicationFactor(3)
+                        .partitions(3)
+                        .configs(
+                                Map.of("cleanup.policy", "delete", "min.insync.replicas", "2", "retention.ms", "60000"))
+                        .build())
+                .build();
+
+        when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
+        when(topicService.listUnsynchronizedTopicsByWildcardName(ns, "test.topic1")).thenReturn(List.of(topic1));
+        doNothing().when(topicService).importTopics(any(), any());
+
+        List<Topic> actual = topicController.importResources("test", "test.topic1", false);
+
+        assertTrue(actual.stream()
+                .anyMatch(t -> t.getMetadata().getName().equals("test.topic1")
+                        && t.getStatus().getMessage().equals("Imported from cluster")
+                        && t.getStatus().getPhase().equals(Topic.TopicPhase.Success)));
+
+        assertFalse(actual.stream()
+                .anyMatch(t -> t.getMetadata().getName().equals("test.topic2")));
+
+        verify(topicService)
+                .importTopics(
+                        eq(ns),
+                        argThat(topics -> topics.stream()
+                                .anyMatch(t -> t.getMetadata().getName().equals("test.topic1"))));
     }
 
     @Test

--- a/src/test/java/com/michelin/ns4kafka/controller/TopicControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/TopicControllerTest.java
@@ -838,7 +838,8 @@ class TopicControllerTest {
                 .build();
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
-        when(topicService.listUnsynchronizedTopicsByWildcardName(ns, "test.topic1")).thenReturn(List.of(topic1));
+        when(topicService.listUnsynchronizedTopicsByWildcardName(ns, "test.topic1"))
+                .thenReturn(List.of(topic1));
         doNothing().when(topicService).importTopics(any(), any());
 
         List<Topic> actual = topicController.importResources("test", "test.topic1", false);
@@ -848,14 +849,10 @@ class TopicControllerTest {
                         && t.getStatus().getMessage().equals("Imported from cluster")
                         && t.getStatus().getPhase().equals(Topic.TopicPhase.Success)));
 
-        assertFalse(actual.stream()
-                .anyMatch(t -> t.getMetadata().getName().equals("test.topic2")));
+        assertFalse(actual.stream().anyMatch(t -> t.getMetadata().getName().equals("test.topic2")));
 
-        verify(topicService)
-                .importTopics(
-                        eq(ns),
-                        argThat(topics -> topics.stream()
-                                .anyMatch(t -> t.getMetadata().getName().equals("test.topic1"))));
+        verify(topicService).importTopics(eq(ns), argThat(topics -> topics.stream()
+                .anyMatch(t -> t.getMetadata().getName().equals("test.topic1"))));
     }
 
     @Test

--- a/src/test/java/com/michelin/ns4kafka/controller/TopicControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/TopicControllerTest.java
@@ -19,7 +19,6 @@
 package com.michelin.ns4kafka.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -827,16 +826,6 @@ class TopicControllerTest {
                         .build())
                 .build();
 
-        Topic topic2 = Topic.builder()
-                .metadata(Metadata.builder().name("test.topic2").build())
-                .spec(Topic.TopicSpec.builder()
-                        .replicationFactor(3)
-                        .partitions(3)
-                        .configs(
-                                Map.of("cleanup.policy", "delete", "min.insync.replicas", "2", "retention.ms", "60000"))
-                        .build())
-                .build();
-
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(topicService.listUnsynchronizedTopicsByWildcardName(ns, "test.topic1"))
                 .thenReturn(List.of(topic1));
@@ -848,8 +837,6 @@ class TopicControllerTest {
                 .anyMatch(t -> t.getMetadata().getName().equals("test.topic1")
                         && t.getStatus().getMessage().equals("Imported from cluster")
                         && t.getStatus().getPhase().equals(Topic.TopicPhase.Success)));
-
-        assertFalse(actual.stream().anyMatch(t -> t.getMetadata().getName().equals("test.topic2")));
 
         verify(topicService).importTopics(eq(ns), argThat(topics -> topics.stream()
                 .anyMatch(t -> t.getMetadata().getName().equals("test.topic1"))));

--- a/src/test/java/com/michelin/ns4kafka/service/TopicServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/TopicServiceTest.java
@@ -1076,7 +1076,8 @@ class TopicServiceTest {
     }
 
     @Test
-    void shouldListUnsynchronizedTopicNamesWithWildcardParameter() throws ExecutionException, InterruptedException, TimeoutException {
+    void shouldListUnsynchronizedTopicNamesWithWildcardParameter()
+            throws ExecutionException, InterruptedException, TimeoutException {
         Namespace ns = Namespace.builder()
                 .metadata(Metadata.builder().name("namespace").cluster("local").build())
                 .build();
@@ -1110,7 +1111,8 @@ class TopicServiceTest {
     }
 
     @Test
-    void shouldListUnsynchronizedTopicNamesWithNameParameter() throws ExecutionException, InterruptedException, TimeoutException {
+    void shouldListUnsynchronizedTopicNamesWithNameParameter()
+            throws ExecutionException, InterruptedException, TimeoutException {
         Namespace ns = Namespace.builder()
                 .metadata(Metadata.builder().name("namespace").cluster("local").build())
                 .build();


### PR DESCRIPTION
This PR adds the possibility to import specific unsynchronized topics from the cluster to Ns4kafka, in addition to the previous capability to import all unsynchronized topics at once.

In the endpoint POST `/topics/_/import`, the query parameter `name` can be used to specifically import one topic or multiple topics following a wildcard string.

Example: 
- `/topics/_/import?name=myTopicName` would only import the topic `myTopicName` if it exists on the cluster but is missing from Ns4kafka
- `/topics/_/import?name=*-test` would import all the unsynchronized topics matching the wildcard `*-test`