### PR TITLE
Add the possibility to import specific connectors

### DIFF
--- a/src/test/java/com/michelin/ns4kafka/controller/ConnectorControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/ConnectorControllerTest.java
@@ -659,16 +659,37 @@ class ConnectorControllerTest {
                 .build();
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
-        when(connectorService.listUnsynchronizedConnectors(ns))
+        when(connectorService.listUnsynchronizedConnectorsByWildcardName(ns, "*"))
                 .thenReturn(Flux.fromIterable(List.of(connector1, connector2)));
         when(connectorService.createOrUpdate(connector1)).thenReturn(connector1);
         when(connectorService.createOrUpdate(connector2)).thenReturn(connector2);
 
-        StepVerifier.create(connectorController.importResources("test", false))
+        StepVerifier.create(connectorController.importResources("test", "*", false))
                 .consumeNextWith(connect1 ->
                         assertEquals("connect1", connect1.getMetadata().getName()))
                 .consumeNextWith(connect2 ->
                         assertEquals("connect2", connect2.getMetadata().getName()))
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldImportConnectorsWithNameParameter() {
+        Namespace ns = Namespace.builder()
+                .metadata(Metadata.builder().name("test").cluster("local").build())
+                .build();
+
+        Connector connector1 = Connector.builder()
+                .metadata(Metadata.builder().name("connect1").build())
+                .build();
+
+        when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
+        when(connectorService.listUnsynchronizedConnectorsByWildcardName(ns, "connect1"))
+                .thenReturn(Flux.fromIterable(List.of(connector1)));
+        when(connectorService.createOrUpdate(connector1)).thenReturn(connector1);
+
+        StepVerifier.create(connectorController.importResources("test", "connect1", false))
+                .consumeNextWith(connect1 ->
+                        assertEquals("connect1", connect1.getMetadata().getName()))
                 .verifyComplete();
     }
 
@@ -689,10 +710,10 @@ class ConnectorControllerTest {
                 .build();
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
-        when(connectorService.listUnsynchronizedConnectors(ns))
+        when(connectorService.listUnsynchronizedConnectorsByWildcardName(ns, "*"))
                 .thenReturn(Flux.fromIterable(List.of(connector1, connector2)));
 
-        StepVerifier.create(connectorController.importResources("test", true))
+        StepVerifier.create(connectorController.importResources("test", "*", true))
                 .consumeNextWith(connect1 ->
                         assertEquals("connect1", connect1.getMetadata().getName()))
                 .consumeNextWith(connect2 ->

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
@@ -879,7 +879,7 @@ class ConnectorServiceTest {
         // no connects exists into Ns4Kafka
         when(connectorRepository.findAllForCluster("local")).thenReturn(List.of());
 
-        StepVerifier.create(connectorService.listUnsynchronizedConnectors(ns))
+        StepVerifier.create(connectorService.listUnsynchronizedConnectorsByWildcardName(ns, "*"))
                 .consumeNextWith(connector ->
                         assertEquals("ns-connect1", connector.getMetadata().getName()))
                 .consumeNextWith(connector ->
@@ -989,7 +989,8 @@ class ConnectorServiceTest {
         when(aclService.isResourceCoveredByAcls(acls, "ns1-connect2")).thenReturn(true);
         when(aclService.isResourceCoveredByAcls(acls, "ns2-connect1")).thenReturn(false);
 
-        StepVerifier.create(connectorService.listUnsynchronizedConnectors(ns)).verifyComplete();
+        StepVerifier.create(connectorService.listUnsynchronizedConnectorsByWildcardName(ns, "*"))
+                .verifyComplete();
     }
 
     @Test
@@ -1068,7 +1069,7 @@ class ConnectorServiceTest {
         when(connectorRepository.findAllForCluster("local")).thenReturn(List.of(c1));
         when(aclService.isResourceCoveredByAcls(acls, "ns-connect1")).thenReturn(true);
 
-        StepVerifier.create(connectorService.listUnsynchronizedConnectors(ns))
+        StepVerifier.create(connectorService.listUnsynchronizedConnectorsByWildcardName(ns, "*"))
                 .consumeNextWith(connector ->
                         assertEquals("ns-connect2", connector.getMetadata().getName()))
                 .consumeNextWith(connector ->

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
@@ -1089,8 +1089,8 @@ class ConnectorServiceTest {
         // init connectorAsyncExecutor
         ConnectorAsyncExecutor connectorAsyncExecutor = mock(ConnectorAsyncExecutor.class);
         when(applicationContext.getBean(
-                ConnectorAsyncExecutor.class,
-                Qualifiers.byName(ns.getMetadata().getCluster())))
+                        ConnectorAsyncExecutor.class,
+                        Qualifiers.byName(ns.getMetadata().getCluster())))
                 .thenReturn(connectorAsyncExecutor);
 
         // list of existing broker connectors
@@ -1142,10 +1142,10 @@ class ConnectorServiceTest {
         when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.CONNECT, "ns-connect2"))
                 .thenReturn(true);
         when(aclService.isNamespaceOwnerOfResource(
-                "namespace", AccessControlEntry.ResourceType.CONNECT, "ns1-connect1"))
+                        "namespace", AccessControlEntry.ResourceType.CONNECT, "ns1-connect1"))
                 .thenReturn(true);
         when(aclService.isNamespaceOwnerOfResource(
-                "namespace", AccessControlEntry.ResourceType.CONNECT, "ns2-connect1"))
+                        "namespace", AccessControlEntry.ResourceType.CONNECT, "ns2-connect1"))
                 .thenReturn(false);
 
         when(aclService.findResourceOwnerGrantedToNamespace(ns, AccessControlEntry.ResourceType.CONNECT))


### PR DESCRIPTION
This PR adds the possibility to import specific unsynchronized connectors from the kconnect cluster to Ns4kafka, in addition to the previous capability to import all unsynchronized connectors at once.

In the endpoint POST `/connectors/_/import`, the query parameter `name` can be used to specifically import one connector or multiple connectors following a wildcard string.

Example:

- `/connectors/_/import?name=myConnectorName` would only import the connector `myConnectorName` if it exists on the cluster but is missing from Ns4kafka
- `/connectors/_/import?name=*-test` would import all the unsynchronized connectors matching the wildcard `*-test`