### PR TITLE
Fix connect synchro thread accumulation in memory

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/service/executor/KafkaAsyncExecutorScheduler.java
+++ b/src/main/java/com/michelin/ns4kafka/service/executor/KafkaAsyncExecutorScheduler.java
@@ -73,7 +73,7 @@ public class KafkaAsyncExecutorScheduler {
 
     /** Schedule connector synchronization. */
     public void scheduleConnectorSynchronization() {
-        Flux.interval(Duration.ofSeconds(12), Duration.ofSeconds(20))
+        Flux.interval(Duration.ofSeconds(12), Duration.ofSeconds(30))
                 .onBackpressureDrop(
                         _ -> log.debug("Skipping next connector synchronization. The previous one is still running."))
                 .concatMap(_ -> Flux.fromIterable(connectorAsyncExecutors).flatMap(ConnectorAsyncExecutor::run))
@@ -85,7 +85,7 @@ public class KafkaAsyncExecutorScheduler {
 
     /** Schedule connector synchronization. */
     public void scheduleConnectHealthCheck() {
-        Flux.interval(Duration.ofSeconds(5), Duration.ofMinutes(1))
+        Flux.interval(Duration.ofSeconds(5), Duration.ofSeconds(60))
                 .onBackpressureDrop(_ ->
                         log.debug("Skipping next Connect cluster health check. The previous one is still running."))
                 .concatMap(


### PR DESCRIPTION
**Context**
Due to connect synchronisation intervals= being too short, it seemed that the Connect synchro threads are accumulating in the application memory, leading to memory leak (java Heap space)

Locally with Intellij Profiler, the retained bytes for `io.netty.util.concurrent.FastThreadLocalThread` increased from 7.78 MB to 16.98 MB after 30 minutes of runtime.
<img width="912" height="674" alt="image" src="https://github.com/user-attachments/assets/3ca310d0-059d-4258-a16d-aabb90ca4abb" />

**Implementation proposition**
This PR rolls back the interval duration change for the connector executor, so there is more time for the garbage collector to close the thread before starting new threads.
