### PR TITLE
Add the possibility to define subject alias

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controller/SchemaController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/SchemaController.java
@@ -18,6 +18,7 @@
  */
 package com.michelin.ns4kafka.controller;
 
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidAliasOwner;
 import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidOwner;
 import static com.michelin.ns4kafka.util.enumation.Kind.SCHEMA;
 import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
@@ -25,13 +26,15 @@ import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
 import com.michelin.ns4kafka.controller.generic.NamespacedResourceController;
 import com.michelin.ns4kafka.model.AuditLog;
 import com.michelin.ns4kafka.model.Namespace;
+import com.michelin.ns4kafka.model.Resource;
 import com.michelin.ns4kafka.model.schema.Schema;
-import com.michelin.ns4kafka.model.schema.SchemaCompatibilityState;
+import com.michelin.ns4kafka.model.schema.SubjectConfigState;
 import com.michelin.ns4kafka.service.NamespaceService;
 import com.michelin.ns4kafka.service.SchemaService;
 import com.michelin.ns4kafka.util.enumation.ApplyStatus;
 import com.michelin.ns4kafka.util.exception.ResourceValidationException;
 import io.micronaut.context.event.ApplicationEventPublisher;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
@@ -49,6 +52,7 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -316,54 +320,91 @@ public class SchemaController extends NamespacedResourceController {
     }
 
     /**
-     * Update the compatibility of a subject.
+     * Update the subject config.
      *
      * @param namespace The namespace
-     * @param subject The subject to update
+     * @param subject The subject config to update
      * @param compatibility The compatibility to apply
-     * @return A schema compatibility state
+     * @param alias The alias to apply
+     * @return A subject config state
      */
     @Post("/{subject}/config")
-    public Mono<HttpResponse<SchemaCompatibilityState>> config(
-            String namespace, @PathVariable String subject, Schema.Compatibility compatibility) {
+    public Mono<HttpResponse<SubjectConfigState>> config(
+            String namespace,
+            @PathVariable String subject,
+            @Nullable Schema.Compatibility compatibility,
+            @Nullable String alias) {
         Namespace ns = getNamespace(namespace);
 
         if (!schemaService.isNamespaceOwnerOfSubject(ns, subject)) {
             return Mono.error(new ResourceValidationException(SCHEMA, subject, invalidOwner(subject)));
         }
 
-        return schemaService
-                .getSubjectLatestVersion(ns, subject)
-                .map(Optional::of)
-                .defaultIfEmpty(Optional.empty())
-                .flatMap(latestSubjectOptional -> {
-                    if (latestSubjectOptional.isEmpty()) {
-                        return Mono.just(HttpResponse.notFound());
-                    }
+        if (alias != null && !schemaService.isNamespaceOwnerOfSubject(ns, alias)) {
+            return Mono.error(new ResourceValidationException(SCHEMA, alias, invalidAliasOwner(alias)));
+        }
 
-                    SchemaCompatibilityState state = SchemaCompatibilityState.builder()
-                            .metadata(latestSubjectOptional.get().getMetadata())
-                            .spec(SchemaCompatibilityState.SchemaCompatibilityStateSpec.builder()
-                                    .compatibility(compatibility)
-                                    .build())
-                            .build();
+        return schemaService.getSubjectConfig(ns, subject).flatMap(response -> {
+            SubjectConfigState state = SubjectConfigState.builder()
+                    .metadata(Resource.Metadata.builder()
+                            .cluster(ns.getMetadata().getCluster())
+                            .namespace(ns.getMetadata().getName())
+                            .name(subject)
+                            .build())
+                    .spec(SubjectConfigState.SubjectConfigStateSpec.builder()
+                            .compatibility(compatibility == null ? response.compatibilityLevel() : compatibility)
+                            .alias(alias == null ? response.alias() : alias)
+                            .build())
+                    .build();
 
-                    if (latestSubjectOptional.get().getSpec().getCompatibility().equals(compatibility)) {
-                        return Mono.just(HttpResponse.ok(state));
-                    }
+            if (Objects.equals(response.compatibilityLevel(), state.getSpec().getCompatibility())
+                    && Objects.equals(response.alias(), state.getSpec().getAlias())) {
+                return Mono.just(HttpResponse.ok(state));
+            }
 
-                    return schemaService
-                            .updateSubjectCompatibility(ns, latestSubjectOptional.get(), compatibility)
-                            .map(_ -> {
-                                sendEventLog(
-                                        latestSubjectOptional.get(),
-                                        ApplyStatus.CHANGED,
-                                        latestSubjectOptional.get().getSpec().getCompatibility(),
-                                        compatibility,
-                                        EMPTY_STRING);
+            return schemaService.updateSubjectConfig(ns, state).map(_ -> {
+                SubjectConfigState.SubjectConfigStateSpec currentConfig =
+                        SubjectConfigState.SubjectConfigStateSpec.builder()
+                                .compatibility(response.compatibilityLevel())
+                                .alias(response.alias())
+                                .build();
 
-                                return HttpResponse.ok(state);
-                            });
-                });
+                sendEventLog(state, ApplyStatus.CHANGED, currentConfig, state.getSpec(), EMPTY_STRING);
+                return HttpResponse.ok(state);
+            });
+        });
+    }
+
+    /**
+     * Delete the subject config.
+     *
+     * @param namespace The namespace
+     * @param subject The subject config to delete
+     * @return The deleted subject config state
+     */
+    @Delete("/{subject}/config")
+    public Mono<HttpResponse<SubjectConfigState>> deleteConfig(String namespace, @PathVariable String subject) {
+        Namespace ns = getNamespace(namespace);
+
+        if (!schemaService.isNamespaceOwnerOfSubject(ns, subject)) {
+            return Mono.error(new ResourceValidationException(SCHEMA, subject, invalidOwner(subject)));
+        }
+
+        return schemaService.deleteSubjectConfig(ns, subject).map(response -> {
+            SubjectConfigState state = SubjectConfigState.builder()
+                    .metadata(Resource.Metadata.builder()
+                            .cluster(ns.getMetadata().getCluster())
+                            .namespace(ns.getMetadata().getName())
+                            .name(subject)
+                            .build())
+                    .spec(SubjectConfigState.SubjectConfigStateSpec.builder()
+                            .compatibility(response.compatibilityLevel())
+                            .alias(response.alias())
+                            .build())
+                    .build();
+
+            sendEventLog(state, ApplyStatus.DELETED, state, null, EMPTY_STRING);
+            return HttpResponse.ok(state);
+        });
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/model/schema/Schema.java
+++ b/src/main/java/com/michelin/ns4kafka/model/schema/Schema.java
@@ -86,8 +86,8 @@ public class Schema extends Resource {
         @Builder.Default
         private SchemaType schemaType = SchemaType.AVRO;
 
-        @Builder.Default
-        private Compatibility compatibility = Compatibility.GLOBAL;
+        private Compatibility compatibility;
+        private String alias;
 
         @Valid private List<Reference> references;
 

--- a/src/main/java/com/michelin/ns4kafka/model/schema/SubjectConfigState.java
+++ b/src/main/java/com/michelin/ns4kafka/model/schema/SubjectConfigState.java
@@ -18,7 +18,7 @@
  */
 package com.michelin.ns4kafka.model.schema;
 
-import static com.michelin.ns4kafka.util.enumation.Kind.SCHEMA_COMPATIBILITY_STATE;
+import static com.michelin.ns4kafka.util.enumation.Kind.SUBJECT_CONFIG_STATE;
 
 import com.michelin.ns4kafka.model.Resource;
 import io.micronaut.core.annotation.Introspected;
@@ -29,15 +29,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
-/** Schema compatibility state. */
+/** Subject config state. */
 @Data
 @Introspected
 @EqualsAndHashCode(callSuper = true)
-public class SchemaCompatibilityState extends Resource {
-    @Valid @NotNull private SchemaCompatibilityState.SchemaCompatibilityStateSpec spec;
+public class SubjectConfigState extends Resource {
+    @Valid @NotNull private SubjectConfigState.SubjectConfigStateSpec spec;
 
     /**
      * Constructor.
@@ -46,20 +45,19 @@ public class SchemaCompatibilityState extends Resource {
      * @param spec The spec
      */
     @Builder
-    public SchemaCompatibilityState(Metadata metadata, SchemaCompatibilityState.SchemaCompatibilityStateSpec spec) {
-        super("v1", SCHEMA_COMPATIBILITY_STATE, metadata);
+    public SubjectConfigState(Metadata metadata, SubjectConfigStateSpec spec) {
+        super("v1", SUBJECT_CONFIG_STATE, metadata);
         this.spec = spec;
     }
 
-    /** Schema compatibility state spec. */
+    /** Subject config state spec. */
     @Getter
     @Builder
     @ToString
     @Introspected
-    @NoArgsConstructor
     @AllArgsConstructor
-    public static class SchemaCompatibilityStateSpec {
-        @Builder.Default
-        private final Schema.Compatibility compatibility = Schema.Compatibility.GLOBAL;
+    public static class SubjectConfigStateSpec {
+        private final Schema.Compatibility compatibility;
+        private final String alias;
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/service/SchemaService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/SchemaService.java
@@ -28,12 +28,13 @@ import com.michelin.ns4kafka.model.AccessControlEntry;
 import com.michelin.ns4kafka.model.Namespace;
 import com.michelin.ns4kafka.model.Resource;
 import com.michelin.ns4kafka.model.schema.Schema;
+import com.michelin.ns4kafka.model.schema.SubjectConfigState;
 import com.michelin.ns4kafka.model.schema.SubjectNameStrategy;
 import com.michelin.ns4kafka.service.client.schema.SchemaRegistryClient;
-import com.michelin.ns4kafka.service.client.schema.entities.SchemaCompatibilityRequest;
-import com.michelin.ns4kafka.service.client.schema.entities.SchemaCompatibilityResponse;
 import com.michelin.ns4kafka.service.client.schema.entities.SchemaRequest;
 import com.michelin.ns4kafka.service.client.schema.entities.SchemaResponse;
+import com.michelin.ns4kafka.service.client.schema.entities.SubjectConfigRequest;
+import com.michelin.ns4kafka.service.client.schema.entities.SubjectConfigResponse;
 import com.michelin.ns4kafka.util.RegexUtils;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
@@ -79,7 +80,7 @@ public class SchemaService {
     public Flux<Schema> findAllForNamespace(Namespace namespace) {
         List<AccessControlEntry> acls = aclService.findResourceOwnerGrantedToNamespace(namespace, TOPIC);
         return schemaRegistryClient
-                .getSubjects(namespace.getMetadata().getCluster())
+                .listSubjects(namespace.getMetadata().getCluster())
                 .filter(subject -> aclService.isResourceCoveredByAcls(acls, extractResourceNameFromSubject(subject)))
                 .map(subject -> Schema.builder()
                         .metadata(Resource.Metadata.builder()
@@ -137,38 +138,44 @@ public class SchemaService {
      * Build the schema spec from the SchemaResponse.
      *
      * @param namespace The namespace
-     * @param subjectOptional The subject object from Http response
+     * @param subjectResponse The subject object from Http response
      * @return A Subject
      */
-    public Mono<Schema> buildSchemaSpec(Namespace namespace, SchemaResponse subjectOptional) {
-        return schemaRegistryClient
-                .getCurrentCompatibilityBySubject(namespace.getMetadata().getCluster(), subjectOptional.subject())
-                .map(Optional::of)
-                .defaultIfEmpty(Optional.empty())
-                .map(currentCompatibilityOptional -> {
-                    Schema.Compatibility compatibility = currentCompatibilityOptional.isPresent()
-                            ? currentCompatibilityOptional.get().compatibilityLevel()
-                            : Schema.Compatibility.GLOBAL;
+    public Mono<Schema> buildSchemaSpec(Namespace namespace, SchemaResponse subjectResponse) {
+        return getSubjectConfig(namespace, subjectResponse.subject())
+                .map(configResponse ->
+                        buildSchemaSpec(namespace, subjectResponse.subject(), subjectResponse, configResponse));
+    }
 
-                    return Schema.builder()
-                            .metadata(Resource.Metadata.builder()
-                                    .cluster(namespace.getMetadata().getCluster())
-                                    .namespace(namespace.getMetadata().getName())
-                                    .name(subjectOptional.subject())
-                                    .build())
-                            .spec(Schema.SchemaSpec.builder()
-                                    .id(subjectOptional.id())
-                                    .version(subjectOptional.version())
-                                    .compatibility(compatibility)
-                                    .schema(subjectOptional.schema())
-                                    .schemaType(
-                                            subjectOptional.schemaType() == null
-                                                    ? AVRO
-                                                    : Schema.SchemaType.valueOf(subjectOptional.schemaType()))
-                                    .references(subjectOptional.references())
-                                    .build())
-                            .build();
-                });
+    /**
+     * Build the schema spec from the SchemaResponse and the SubjectConfigResponse.
+     *
+     * @param namespace The namespace
+     * @param subjectResponse The subject object from Http response
+     * @param configResponse The subject config object from Http response
+     * @return A Subject
+     */
+    public Schema buildSchemaSpec(
+            Namespace namespace, String subject, SchemaResponse subjectResponse, SubjectConfigResponse configResponse) {
+        return Schema.builder()
+                .metadata(Resource.Metadata.builder()
+                        .cluster(namespace.getMetadata().getCluster())
+                        .namespace(namespace.getMetadata().getName())
+                        .name(subject)
+                        .build())
+                .spec(Schema.SchemaSpec.builder()
+                        .id(subjectResponse.id())
+                        .version(subjectResponse.version())
+                        .compatibility(configResponse.compatibilityLevel())
+                        .alias(configResponse.alias())
+                        .schema(subjectResponse.schema())
+                        .schemaType(
+                                subjectResponse.schemaType() == null
+                                        ? Schema.SchemaType.AVRO
+                                        : Schema.SchemaType.valueOf(subjectResponse.schemaType()))
+                        .references(subjectResponse.references())
+                        .build())
+                .build();
     }
 
     /**
@@ -182,7 +189,7 @@ public class SchemaService {
     public Mono<Schema> getSubjectByVersion(Namespace namespace, String subject, String version) {
         return schemaRegistryClient
                 .getSubject(namespace.getMetadata().getCluster(), subject, version)
-                .flatMap(subjectOptional -> buildSchemaSpec(namespace, subjectOptional));
+                .flatMap(subjectResponse -> buildSchemaSpec(namespace, subjectResponse));
     }
 
     /**
@@ -324,29 +331,44 @@ public class SchemaService {
     }
 
     /**
-     * Update the compatibility of a subject.
+     * Get subject config.
      *
      * @param namespace The namespace
-     * @param schema The schema
-     * @param compatibility The compatibility to apply
+     * @param subject The subject
+     * @return A Subject
      */
-    public Mono<SchemaCompatibilityResponse> updateSubjectCompatibility(
-            Namespace namespace, Schema schema, Schema.Compatibility compatibility) {
-        if (compatibility.equals(Schema.Compatibility.GLOBAL)) {
-            return schemaRegistryClient.deleteCurrentCompatibilityBySubject(
-                    namespace.getMetadata().getCluster(), schema.getMetadata().getName());
-        } else {
-            return schemaRegistryClient.updateSubjectCompatibility(
-                    namespace.getMetadata().getCluster(),
-                    schema.getMetadata().getName(),
-                    SchemaCompatibilityRequest.builder()
-                            .compatibility(compatibility.toString())
-                            .build());
-        }
+    public Mono<SubjectConfigResponse> getSubjectConfig(Namespace namespace, String subject) {
+        return schemaRegistryClient.getSubjectConfig(namespace.getMetadata().getCluster(), subject);
     }
 
     /**
-     * Does the namespace is owner of the given schema.
+     * Update the subject config.
+     *
+     * @param namespace The namespace
+     * @param state The subject config state
+     */
+    public Mono<SubjectConfigResponse> updateSubjectConfig(Namespace namespace, SubjectConfigState state) {
+        return schemaRegistryClient.createOrUpdateSubjectConfig(
+                namespace.getMetadata().getCluster(),
+                state.getMetadata().getName(),
+                SubjectConfigRequest.builder()
+                        .compatibility(state.getSpec().getCompatibility())
+                        .alias(state.getSpec().getAlias())
+                        .build());
+    }
+
+    /**
+     * Delete the subject config.
+     *
+     * @param namespace The namespace
+     * @param subject The subject name
+     */
+    public Mono<SubjectConfigResponse> deleteSubjectConfig(Namespace namespace, String subject) {
+        return schemaRegistryClient.deleteSubjectConfig(namespace.getMetadata().getCluster(), subject);
+    }
+
+    /**
+     * Check if the namespace is owner of the given subject.
      *
      * <p>For topic name strategy and topic record name strategy, the validation is done against the topic name.
      *

--- a/src/main/java/com/michelin/ns4kafka/service/client/schema/SchemaRegistryClient.java
+++ b/src/main/java/com/michelin/ns4kafka/service/client/schema/SchemaRegistryClient.java
@@ -21,10 +21,10 @@ package com.michelin.ns4kafka.service.client.schema;
 import com.michelin.ns4kafka.property.ManagedClusterProperties;
 import com.michelin.ns4kafka.service.client.schema.entities.GraphQueryResponse;
 import com.michelin.ns4kafka.service.client.schema.entities.SchemaCompatibilityCheckResponse;
-import com.michelin.ns4kafka.service.client.schema.entities.SchemaCompatibilityRequest;
-import com.michelin.ns4kafka.service.client.schema.entities.SchemaCompatibilityResponse;
 import com.michelin.ns4kafka.service.client.schema.entities.SchemaRequest;
 import com.michelin.ns4kafka.service.client.schema.entities.SchemaResponse;
+import com.michelin.ns4kafka.service.client.schema.entities.SubjectConfigRequest;
+import com.michelin.ns4kafka.service.client.schema.entities.SubjectConfigResponse;
 import com.michelin.ns4kafka.service.client.schema.entities.TagInfo;
 import com.michelin.ns4kafka.service.client.schema.entities.TagTopicInfo;
 import com.michelin.ns4kafka.service.client.schema.entities.TopicDescriptionUpdateBody;
@@ -79,6 +79,26 @@ public class SchemaRegistryClient {
     }
 
     /**
+     * Get the global config.
+     *
+     * @param kafkaCluster The Kafka cluster
+     * @return The current schema config
+     */
+    @Retryable(
+            delay = "${ns4kafka.retry.delay}",
+            attempts = "${ns4kafka.retry.attempt}",
+            multiplier = "${ns4kafka.retry.multiplier}",
+            includes = ReadTimeoutException.class)
+    public Mono<SubjectConfigResponse> getGlobalConfig(String kafkaCluster) {
+        ManagedClusterProperties.SchemaRegistryProperties config = getSchemaRegistry(kafkaCluster);
+
+        HttpRequest<?> request = HttpRequest.GET(URI.create(StringUtils.prependUri(config.getUrl(), CONFIG)))
+                .basicAuth(config.getBasicAuthUsername(), config.getBasicAuthPassword());
+
+        return Mono.from(httpClient.retrieve(request, SubjectConfigResponse.class));
+    }
+
+    /**
      * List subjects.
      *
      * @param kafkaCluster The Kafka cluster
@@ -89,7 +109,7 @@ public class SchemaRegistryClient {
             attempts = "${ns4kafka.retry.attempt}",
             multiplier = "${ns4kafka.retry.multiplier}",
             includes = ReadTimeoutException.class)
-    public Flux<String> getSubjects(String kafkaCluster) {
+    public Flux<String> listSubjects(String kafkaCluster) {
         ManagedClusterProperties.SchemaRegistryProperties config = getSchemaRegistry(kafkaCluster);
         HttpRequest<?> request = HttpRequest.GET(URI.create(StringUtils.prependUri(config.getUrl(), "/subjects")))
                 .basicAuth(config.getBasicAuthUsername(), config.getBasicAuthPassword());
@@ -97,7 +117,7 @@ public class SchemaRegistryClient {
     }
 
     /**
-     * Get a subject by it name and id.
+     * Get a subject by name and version.
      *
      * @param kafkaCluster The Kafka cluster
      * @param subject The subject
@@ -187,7 +207,7 @@ public class SchemaRegistryClient {
      *
      * @param kafkaCluster The Kafka cluster
      * @param subject The subject
-     * @param hardDelete Should the subject be hard deleted or not
+     * @param hardDelete Should the subject be hard deleted or not?
      * @return The versions of the deleted subject
      */
     @Retryable(
@@ -212,7 +232,7 @@ public class SchemaRegistryClient {
      * @param kafkaCluster The Kafka cluster
      * @param subject The subject
      * @param version The version
-     * @param hardDelete Should the subject be hard deleted or not
+     * @param hardDelete Should the subject be hard deleted or not?
      * @return The version of the deleted subject
      */
     @Retryable(
@@ -265,20 +285,20 @@ public class SchemaRegistryClient {
     }
 
     /**
-     * Update the subject compatibility.
+     * Create or update the subject config.
      *
      * @param kafkaCluster The Kafka cluster
      * @param subject The subject
-     * @param body The schema compatibility request
-     * @return The schema compatibility update
+     * @param body The subject config request
+     * @return The created or updated subject config
      */
     @Retryable(
             delay = "${ns4kafka.retry.delay}",
             attempts = "${ns4kafka.retry.attempt}",
             multiplier = "${ns4kafka.retry.multiplier}",
             includes = ReadTimeoutException.class)
-    public Mono<SchemaCompatibilityResponse> updateSubjectCompatibility(
-            String kafkaCluster, String subject, SchemaCompatibilityRequest body) {
+    public Mono<SubjectConfigResponse> createOrUpdateSubjectConfig(
+            String kafkaCluster, String subject, SubjectConfigRequest body) {
         ManagedClusterProperties.SchemaRegistryProperties config = getSchemaRegistry(kafkaCluster);
         String encodedSubject = URLEncoder.encode(subject, StandardCharsets.UTF_8);
 
@@ -286,22 +306,22 @@ public class SchemaRegistryClient {
                         URI.create(StringUtils.prependUri(config.getUrl(), CONFIG + encodedSubject)), body)
                 .basicAuth(config.getBasicAuthUsername(), config.getBasicAuthPassword());
 
-        return Mono.from(httpClient.retrieve(request, SchemaCompatibilityResponse.class));
+        return Mono.from(httpClient.retrieve(request, SubjectConfigResponse.class));
     }
 
     /**
-     * Get the current compatibility by subject.
+     * Get the subject config.
      *
      * @param kafkaCluster The Kafka cluster
      * @param subject The subject
-     * @return The current schema compatibility
+     * @return The subject config
      */
     @Retryable(
             delay = "${ns4kafka.retry.delay}",
             attempts = "${ns4kafka.retry.attempt}",
             multiplier = "${ns4kafka.retry.multiplier}",
             includes = ReadTimeoutException.class)
-    public Mono<SchemaCompatibilityResponse> getCurrentCompatibilityBySubject(String kafkaCluster, String subject) {
+    public Mono<SubjectConfigResponse> getSubjectConfig(String kafkaCluster, String subject) {
         ManagedClusterProperties.SchemaRegistryProperties config = getSchemaRegistry(kafkaCluster);
         String encodedSubject = URLEncoder.encode(subject, StandardCharsets.UTF_8);
 
@@ -309,25 +329,29 @@ public class SchemaRegistryClient {
                         URI.create(StringUtils.prependUri(config.getUrl(), CONFIG + encodedSubject)))
                 .basicAuth(config.getBasicAuthUsername(), config.getBasicAuthPassword());
 
-        return Mono.from(httpClient.retrieve(request, SchemaCompatibilityResponse.class))
+        return Mono.from(httpClient.retrieve(request, SubjectConfigResponse.class))
                 .onErrorResume(
                         HttpClientResponseException.class,
-                        ex -> ex.getStatus().equals(HttpStatus.NOT_FOUND) ? Mono.empty() : Mono.error(ex));
+                        ex -> ex.getStatus().equals(HttpStatus.NOT_FOUND)
+                                ? getGlobalConfig(kafkaCluster).map(response -> SubjectConfigResponse.builder()
+                                        .compatibilityLevel(response.compatibilityLevel())
+                                        .build())
+                                : Mono.error(ex));
     }
 
     /**
-     * Delete current compatibility by subject.
+     * Delete current config.
      *
      * @param kafkaCluster The Kafka cluster
      * @param subject The subject
-     * @return The deleted schema compatibility
+     * @return The deleted subject config
      */
     @Retryable(
             delay = "${ns4kafka.retry.delay}",
             attempts = "${ns4kafka.retry.attempt}",
             multiplier = "${ns4kafka.retry.multiplier}",
             includes = ReadTimeoutException.class)
-    public Mono<SchemaCompatibilityResponse> deleteCurrentCompatibilityBySubject(String kafkaCluster, String subject) {
+    public Mono<SubjectConfigResponse> deleteSubjectConfig(String kafkaCluster, String subject) {
         ManagedClusterProperties.SchemaRegistryProperties config = getSchemaRegistry(kafkaCluster);
         String encodedSubject = URLEncoder.encode(subject, StandardCharsets.UTF_8);
 
@@ -335,7 +359,7 @@ public class SchemaRegistryClient {
                         URI.create(StringUtils.prependUri(config.getUrl(), CONFIG + encodedSubject)))
                 .basicAuth(config.getBasicAuthUsername(), config.getBasicAuthPassword());
 
-        return Mono.from(httpClient.retrieve(request, SchemaCompatibilityResponse.class));
+        return Mono.from(httpClient.retrieve(request, SubjectConfigResponse.class));
     }
 
     /**

--- a/src/main/java/com/michelin/ns4kafka/service/client/schema/entities/SubjectConfigRequest.java
+++ b/src/main/java/com/michelin/ns4kafka/service/client/schema/entities/SubjectConfigRequest.java
@@ -19,12 +19,16 @@
 package com.michelin.ns4kafka.service.client.schema.entities;
 
 import com.michelin.ns4kafka.model.schema.Schema;
+import io.micronaut.core.annotation.Nullable;
 import lombok.Builder;
 
 /**
- * Schema compatibility response.
+ * Subject config request.
  *
- * @param compatibilityLevel The compatibility level
+ * @param compatibility The compatibility
+ * @param alias The alias
  */
 @Builder
-public record SchemaCompatibilityResponse(Schema.Compatibility compatibilityLevel) {}
+public record SubjectConfigRequest(
+        @Nullable Schema.Compatibility compatibility,
+        @Nullable String alias) {}

--- a/src/main/java/com/michelin/ns4kafka/service/client/schema/entities/SubjectConfigResponse.java
+++ b/src/main/java/com/michelin/ns4kafka/service/client/schema/entities/SubjectConfigResponse.java
@@ -18,12 +18,14 @@
  */
 package com.michelin.ns4kafka.service.client.schema.entities;
 
+import com.michelin.ns4kafka.model.schema.Schema;
 import lombok.Builder;
 
 /**
- * Schema compatibility request.
+ * Subject config response.
  *
- * @param compatibility The compatibility
+ * @param compatibilityLevel The compatibility level
+ * @param alias The alias
  */
 @Builder
-public record SchemaCompatibilityRequest(String compatibility) {}
+public record SubjectConfigResponse(Schema.Compatibility compatibilityLevel, String alias) {}

--- a/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
+++ b/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
@@ -40,6 +40,7 @@ public class FormatErrorUtils {
     private static final String OPERATION_APPLY = "apply";
     private static final String OPERATION_DELETE = "delete";
     private static final String FIELD_NAME = "name";
+    private static final String FIELD_ALIAS = "alias";
     private static final String INVALID_FIELD = "Invalid value \"%s\" for field \"%s\": %s.";
     private static final String INVALID_FIELDS = "Invalid value \"%s/%s\" for fields \"%s/%s\": %s.";
     private static final String INVALID_EMPTY_FIELD = "Invalid empty value for field \"%s\": %s.";
@@ -599,6 +600,16 @@ public class FormatErrorUtils {
      */
     public static String invalidOwner(String invalidNameValue) {
         return invalidOwner(FIELD_NAME, invalidNameValue);
+    }
+
+    /**
+     * Invalid owner.
+     *
+     * @param invalidAliasValue the invalid field value
+     * @return the error message
+     */
+    public static String invalidAliasOwner(String invalidAliasValue) {
+        return invalidOwner(FIELD_ALIAS, invalidAliasValue);
     }
 
     /**

--- a/src/main/java/com/michelin/ns4kafka/util/enumation/Kind.java
+++ b/src/main/java/com/michelin/ns4kafka/util/enumation/Kind.java
@@ -37,7 +37,7 @@ public enum Kind {
     RESOURCE_QUOTA_RESPONSE("ResourceQuotaResponse"),
     ROLE_BINDING("RoleBinding"),
     SCHEMA("Schema"),
-    SCHEMA_COMPATIBILITY_STATE("SchemaCompatibilityState"),
+    SUBJECT_CONFIG_STATE("SubjectConfigState"),
     STATUS("Status"),
     TOPIC("Topic"),
     VAULT_RESPONSE("VaultResponse");

--- a/src/test/java/com/michelin/ns4kafka/integration/SchemaIntegrationTest.java
+++ b/src/test/java/com/michelin/ns4kafka/integration/SchemaIntegrationTest.java
@@ -31,9 +31,9 @@ import com.michelin.ns4kafka.model.Namespace;
 import com.michelin.ns4kafka.model.Resource;
 import com.michelin.ns4kafka.model.RoleBinding;
 import com.michelin.ns4kafka.model.schema.Schema;
-import com.michelin.ns4kafka.model.schema.SchemaCompatibilityState;
-import com.michelin.ns4kafka.service.client.schema.entities.SchemaCompatibilityResponse;
+import com.michelin.ns4kafka.model.schema.SubjectConfigState;
 import com.michelin.ns4kafka.service.client.schema.entities.SchemaResponse;
+import com.michelin.ns4kafka.service.client.schema.entities.SubjectConfigResponse;
 import com.michelin.ns4kafka.validation.TopicValidator;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
@@ -184,11 +184,11 @@ class SchemaIntegrationTest extends SchemaRegistryIntegrationTest {
                         HttpRequest.create(HttpMethod.POST, "/api/namespaces/ns1/schemas/ns1-subject0-value/config")
                                 .bearerAuth(token)
                                 .body(Map.of("compatibility", Schema.Compatibility.FORWARD)),
-                        SchemaCompatibilityState.class);
+                        SubjectConfigState.class);
 
-        SchemaCompatibilityResponse updatedConfig = schemaRegistryClient
+        SubjectConfigResponse updatedConfig = schemaRegistryClient
                 .toBlocking()
-                .retrieve(HttpRequest.GET("/config/ns1-subject0-value"), SchemaCompatibilityResponse.class);
+                .retrieve(HttpRequest.GET("/config/ns1-subject0-value"), SubjectConfigResponse.class);
 
         assertEquals(Schema.Compatibility.FORWARD, updatedConfig.compatibilityLevel());
 
@@ -264,11 +264,11 @@ class SchemaIntegrationTest extends SchemaRegistryIntegrationTest {
                         HttpRequest.create(HttpMethod.POST, "/api/namespaces/ns1/schemas/ns1-subject1-value/config")
                                 .bearerAuth(token)
                                 .body(Map.of("compatibility", Schema.Compatibility.FORWARD)),
-                        SchemaCompatibilityState.class);
+                        SubjectConfigState.class);
 
-        SchemaCompatibilityResponse updatedConfig = schemaRegistryClient
+        SubjectConfigResponse updatedConfig = schemaRegistryClient
                 .toBlocking()
-                .retrieve(HttpRequest.GET("/config/ns1-subject1-value"), SchemaCompatibilityResponse.class);
+                .retrieve(HttpRequest.GET("/config/ns1-subject1-value"), SubjectConfigResponse.class);
 
         assertEquals(Schema.Compatibility.FORWARD, updatedConfig.compatibilityLevel());
 

--- a/src/test/java/com/michelin/ns4kafka/service/SchemaServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/SchemaServiceTest.java
@@ -32,11 +32,12 @@ import com.michelin.ns4kafka.model.AccessControlEntry;
 import com.michelin.ns4kafka.model.Namespace;
 import com.michelin.ns4kafka.model.Resource;
 import com.michelin.ns4kafka.model.schema.Schema;
+import com.michelin.ns4kafka.model.schema.SubjectConfigState;
 import com.michelin.ns4kafka.model.schema.SubjectNameStrategy;
 import com.michelin.ns4kafka.service.client.schema.SchemaRegistryClient;
 import com.michelin.ns4kafka.service.client.schema.entities.SchemaCompatibilityCheckResponse;
-import com.michelin.ns4kafka.service.client.schema.entities.SchemaCompatibilityResponse;
 import com.michelin.ns4kafka.service.client.schema.entities.SchemaResponse;
+import com.michelin.ns4kafka.service.client.schema.entities.SubjectConfigResponse;
 import com.michelin.ns4kafka.validation.TopicValidator;
 import java.util.Arrays;
 import java.util.Collections;
@@ -96,7 +97,7 @@ class SchemaServiceTest {
         when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC))
                 .thenReturn(acls);
 
-        when(schemaRegistryClient.getSubjects(namespace.getMetadata().getCluster()))
+        when(schemaRegistryClient.listSubjects(namespace.getMetadata().getCluster()))
                 .thenReturn(Flux.fromIterable(subjectsResponse));
         when(aclService.isResourceCoveredByAcls(acls, "prefix.schema-one")).thenReturn(true);
         when(aclService.isResourceCoveredByAcls(acls, "prefix2.schema-two")).thenReturn(true);
@@ -114,7 +115,7 @@ class SchemaServiceTest {
     void shouldListSchemasWhenEmpty() {
         Namespace namespace = buildNamespace();
 
-        when(schemaRegistryClient.getSubjects(namespace.getMetadata().getCluster()))
+        when(schemaRegistryClient.listSubjects(namespace.getMetadata().getCluster()))
                 .thenReturn(Flux.empty());
 
         StepVerifier.create(schemaService.findAllForNamespace(namespace)).verifyComplete();
@@ -148,7 +149,7 @@ class SchemaServiceTest {
 
         when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC))
                 .thenReturn(acls);
-        when(schemaRegistryClient.getSubjects(namespace.getMetadata().getCluster()))
+        when(schemaRegistryClient.listSubjects(namespace.getMetadata().getCluster()))
                 .thenReturn(Flux.fromIterable(subjectsResponse));
         when(aclService.isResourceCoveredByAcls(acls, "prefix.schema-one")).thenReturn(true);
         when(aclService.isResourceCoveredByAcls(acls, "prefix2.schema-two")).thenReturn(true);
@@ -212,7 +213,7 @@ class SchemaServiceTest {
 
         when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC))
                 .thenReturn(acls);
-        when(schemaRegistryClient.getSubjects(namespace.getMetadata().getCluster()))
+        when(schemaRegistryClient.listSubjects(namespace.getMetadata().getCluster()))
                 .thenReturn(Flux.fromIterable(subjectsResponse));
         when(aclService.isResourceCoveredByAcls(eq(acls), anyString())).thenReturn(true);
 
@@ -263,12 +264,11 @@ class SchemaServiceTest {
     @Test
     void shouldGetSubjectLatestVersion() {
         Namespace namespace = buildNamespace();
-        SchemaCompatibilityResponse compatibilityResponse = buildCompatibilityResponse();
+        SubjectConfigResponse compatibilityResponse = buildCompatibilityResponse();
 
         when(schemaRegistryClient.getSubject(namespace.getMetadata().getCluster(), "prefix.schema-one", "latest"))
                 .thenReturn(Mono.just(buildSchemaResponse("prefix.schema-one")));
-        when(schemaRegistryClient.getCurrentCompatibilityBySubject(any(), any()))
-                .thenReturn(Mono.just(compatibilityResponse));
+        when(schemaRegistryClient.getSubjectConfig(any(), any())).thenReturn(Mono.just(compatibilityResponse));
 
         StepVerifier.create(schemaService.getSubjectLatestVersion(namespace, "prefix.schema-one"))
                 .consumeNextWith(latestSubject -> {
@@ -415,39 +415,21 @@ class SchemaServiceTest {
     }
 
     @Test
-    void shouldUpdateSchemaCompatibilityWhenResettingToDefault() {
+    void shouldUpdateSubjectConfig() {
         Namespace namespace = buildNamespace();
-        Schema schema = buildSchema("prefix.schema-one-value");
+        SubjectConfigState state = buildState();
 
-        when(schemaRegistryClient.deleteCurrentCompatibilityBySubject(any(), any()))
-                .thenReturn(Mono.just(SchemaCompatibilityResponse.builder()
+        when(schemaRegistryClient.createOrUpdateSubjectConfig(any(), any(), any()))
+                .thenReturn(Mono.just(SubjectConfigResponse.builder()
                         .compatibilityLevel(Schema.Compatibility.FORWARD)
                         .build()));
 
-        StepVerifier.create(schemaService.updateSubjectCompatibility(namespace, schema, Schema.Compatibility.GLOBAL))
+        StepVerifier.create(schemaService.updateSubjectConfig(namespace, state))
                 .consumeNextWith(schemaCompatibilityResponse ->
                         assertEquals(Schema.Compatibility.FORWARD, schemaCompatibilityResponse.compatibilityLevel()))
                 .verifyComplete();
 
-        verify(schemaRegistryClient).deleteCurrentCompatibilityBySubject(any(), any());
-    }
-
-    @Test
-    void shouldUpdateSubjectCompatibility() {
-        Namespace namespace = buildNamespace();
-        Schema schema = buildSchema("prefix.schema-one-value");
-
-        when(schemaRegistryClient.updateSubjectCompatibility(any(), any(), any()))
-                .thenReturn(Mono.just(SchemaCompatibilityResponse.builder()
-                        .compatibilityLevel(Schema.Compatibility.FORWARD)
-                        .build()));
-
-        StepVerifier.create(schemaService.updateSubjectCompatibility(namespace, schema, Schema.Compatibility.FORWARD))
-                .consumeNextWith(schemaCompatibilityResponse ->
-                        assertEquals(Schema.Compatibility.FORWARD, schemaCompatibilityResponse.compatibilityLevel()))
-                .verifyComplete();
-
-        verify(schemaRegistryClient).updateSubjectCompatibility(any(), any(), any());
+        verify(schemaRegistryClient).createOrUpdateSubjectConfig(any(), any(), any());
     }
 
     @Test
@@ -469,12 +451,11 @@ class SchemaServiceTest {
     void shouldValidateSchema() {
         Namespace namespace = buildNamespace();
         Schema schema = buildSchema("prefix.schema-one-value");
-        SchemaCompatibilityResponse compatibilityResponse = buildCompatibilityResponse();
+        SubjectConfigResponse compatibilityResponse = buildCompatibilityResponse();
 
         when(schemaRegistryClient.getSubject(namespace.getMetadata().getCluster(), "header-value", "1"))
                 .thenReturn(Mono.just(buildSchemaResponse("subject-reference")));
-        when(schemaRegistryClient.getCurrentCompatibilityBySubject(any(), any()))
-                .thenReturn(Mono.just(compatibilityResponse));
+        when(schemaRegistryClient.getSubjectConfig(any(), any())).thenReturn(Mono.just(compatibilityResponse));
 
         StepVerifier.create(schemaService.validateSchema(namespace, schema))
                 .consumeNextWith(errors -> assertTrue(errors.isEmpty()))
@@ -510,12 +491,11 @@ class SchemaServiceTest {
                                 .build()))
                         .build())
                 .build();
-        SchemaCompatibilityResponse compatibilityResponse = buildCompatibilityResponse();
+        SubjectConfigResponse compatibilityResponse = buildCompatibilityResponse();
 
         when(schemaRegistryClient.getSubject(namespace.getMetadata().getCluster(), "header-value", "1"))
                 .thenReturn(Mono.just(buildSchemaResponse("subject-reference")));
-        when(schemaRegistryClient.getCurrentCompatibilityBySubject(any(), any()))
-                .thenReturn(Mono.just(compatibilityResponse));
+        when(schemaRegistryClient.getSubjectConfig(any(), any())).thenReturn(Mono.just(compatibilityResponse));
 
         StepVerifier.create(schemaService.validateSchema(namespace, schema))
                 .consumeNextWith(errors -> assertEquals(expectedResult, errors.isEmpty()))
@@ -538,12 +518,11 @@ class SchemaServiceTest {
         Namespace namespace = buildNamespace();
         Schema schema = buildSchema("prefix.schema-one-value");
         SchemaResponse schemaResponse = buildReferenceSchemaResponse("header-value");
-        SchemaCompatibilityResponse compatibilityResponse = buildCompatibilityResponse();
+        SubjectConfigResponse compatibilityResponse = buildCompatibilityResponse();
 
         when(schemaRegistryClient.getSubject(namespace.getMetadata().getCluster(), "header-value", "1"))
                 .thenReturn(Mono.just(schemaResponse));
-        when(schemaRegistryClient.getCurrentCompatibilityBySubject(any(), any()))
-                .thenReturn(Mono.just(compatibilityResponse));
+        when(schemaRegistryClient.getSubjectConfig(any(), any())).thenReturn(Mono.just(compatibilityResponse));
 
         StepVerifier.create(schemaService.getSchemaReferences(namespace, schema))
                 .consumeNextWith(refs -> assertTrue(
@@ -555,13 +534,12 @@ class SchemaServiceTest {
     void shouldBeEqualByCanonicalStringAndRefs() {
         Namespace namespace = buildNamespace();
         Schema schema = buildSchema("prefix.schema-one-value");
-        SchemaCompatibilityResponse compatibilityResponse = buildCompatibilityResponse();
+        SubjectConfigResponse compatibilityResponse = buildCompatibilityResponse();
         Schema schemaV2 = buildSchemaV2();
 
         when(schemaRegistryClient.getSubject(namespace.getMetadata().getCluster(), "header-value", "1"))
                 .thenReturn(Mono.just(buildReferenceSchemaResponse("header-value")));
-        when(schemaRegistryClient.getCurrentCompatibilityBySubject(any(), any()))
-                .thenReturn(Mono.just(compatibilityResponse));
+        when(schemaRegistryClient.getSubjectConfig(any(), any())).thenReturn(Mono.just(compatibilityResponse));
 
         StepVerifier.create(schemaService.existInOldVersions(namespace, schema, List.of(schema, schemaV2)))
                 .consumeNextWith(Assertions::assertTrue)
@@ -597,12 +575,11 @@ class SchemaServiceTest {
         Namespace namespace = buildNamespace();
         Schema schema = buildSchema("prefix.schema-one-value");
         Schema schemaV2 = buildSchemaV2();
-        SchemaCompatibilityResponse compatibilityResponse = buildCompatibilityResponse();
+        SubjectConfigResponse compatibilityResponse = buildCompatibilityResponse();
 
         when(schemaRegistryClient.getSubject(namespace.getMetadata().getCluster(), "header-value", "1"))
                 .thenReturn(Mono.just(buildReferenceSchemaResponse("header-value")));
-        when(schemaRegistryClient.getCurrentCompatibilityBySubject(any(), any()))
-                .thenReturn(Mono.just(compatibilityResponse));
+        when(schemaRegistryClient.getSubjectConfig(any(), any())).thenReturn(Mono.just(compatibilityResponse));
 
         StepVerifier.create(schemaService.existInOldVersions(namespace, schemaV2, List.of(schema)))
                 .consumeNextWith(Assertions::assertFalse)
@@ -613,12 +590,11 @@ class SchemaServiceTest {
     void shouldExtractRecordName() {
         Namespace namespace = buildNamespace();
         Schema schema = buildSchema("com.michelin.kafka.producer.showcase.avro.PersonAvro");
-        SchemaCompatibilityResponse compatibilityResponse = buildCompatibilityResponse();
+        SubjectConfigResponse compatibilityResponse = buildCompatibilityResponse();
 
         when(schemaRegistryClient.getSubject(namespace.getMetadata().getCluster(), "header-value", "1"))
                 .thenReturn(Mono.just(buildReferenceSchemaResponse("header-value")));
-        when(schemaRegistryClient.getCurrentCompatibilityBySubject(any(), any()))
-                .thenReturn(Mono.just(compatibilityResponse));
+        when(schemaRegistryClient.getSubjectConfig(any(), any())).thenReturn(Mono.just(compatibilityResponse));
 
         StepVerifier.create(schemaService.extractRecordName(namespace, schema))
                 .consumeNextWith(result -> assertEquals("com.michelin.kafka.producer.showcase.avro.PersonAvro", result))
@@ -666,7 +642,7 @@ class SchemaServiceTest {
                         .build())
                 .build();
 
-        SchemaCompatibilityResponse compatibilityResponse = buildCompatibilityResponse();
+        SubjectConfigResponse compatibilityResponse = buildCompatibilityResponse();
         when(schemaRegistryClient.getSubject(namespace.getMetadata().getCluster(), "abc.customer-value", "1"))
                 .thenReturn(Mono.just(SchemaResponse.builder()
                         .id(1)
@@ -694,8 +670,7 @@ class SchemaServiceTest {
                                 + "\"name\":\"Order\",\"fields\":[{\"name\":\"id\",\"type\":[\"null\",\"string\"],"
                                 + "\"default\":null,\"doc\":\"Header ID\"}]}")
                         .build()));
-        when(schemaRegistryClient.getCurrentCompatibilityBySubject(any(), any()))
-                .thenReturn(Mono.just(compatibilityResponse));
+        when(schemaRegistryClient.getSubjectConfig(any(), any())).thenReturn(Mono.just(compatibilityResponse));
 
         StepVerifier.create(schemaService.extractRecordName(namespace, schema))
                 .consumeNextWith(result -> assertEquals("com.michelin.kafka.avro.AllTypes", result))
@@ -892,9 +867,20 @@ class SchemaServiceTest {
                 .build();
     }
 
-    private SchemaCompatibilityResponse buildCompatibilityResponse() {
-        return SchemaCompatibilityResponse.builder()
+    private SubjectConfigResponse buildCompatibilityResponse() {
+        return SubjectConfigResponse.builder()
                 .compatibilityLevel(Schema.Compatibility.BACKWARD)
+                .build();
+    }
+
+    private SubjectConfigState buildState() {
+        return SubjectConfigState.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("prefix.schema-one-value")
+                        .build())
+                .spec(SubjectConfigState.SubjectConfigStateSpec.builder()
+                        .compatibility(Schema.Compatibility.BACKWARD)
+                        .build())
                 .build();
     }
 }


### PR DESCRIPTION
**Implementation proposal**
- List schemas
  - Alias is also returned when listing exactly one subject, in addition to the compatibility
  - When listing a subject with no schema but a subject config, an empty list is returned -> Confluent plans to develop a Schema registry feature to list the subject config. Then the ns4kafka subject listing can be enhanced for this case

- Register alias
  - The compatibility and alias are registered as "**subject config**"
  - The subject config can be registered **even if the subject does not exist** (useful for aliases) -> **Behaviour change**
  - The endpoint `POST /{subject}/config` only queries the subject config to check the current config values
  - If alias or compatibility is null, the endpoint uses the existing value if any, before registering

- Global compatibility
  - Reminder:
    - For a specific subject, the Schema Registry uses the global compatibility when no subject **config** is defined for this subject
    - When registering a subject config without any compatibility (for example: with alias only), the default applied compatibility for the subject will be `BACKWARD`, regardless of the global Schema Registry config
  - The old behaviour "deleting the subject config when the ns4kafka compatibility is `GLOBAL`" does not hold anymore when the user wants to register the alias only: the ns4kafka compatibility `GLOBAL` would be set by default, the subject config would be deleted.
  - So make things simpler, the **`GLOBAL` value for compatibility is removed**, and the global compatibility is queried every time it is needed

- Delete compatibility & alias
  - A new endpoint `DELETE /{subject}/config` is added to delete the subject config (alias & compatibility)
  - If both alias and compatibility are defined, and only one of them needs to be deleted -> use the endpoint to delete the whole config, then create the compatibility or the alias if needed -> an enhancement can be implemented later on this endpoint