### PR TITLE
Enable LIST namespaces API for non-admin users

### DIFF
--- a/src/test/java/com/michelin/ns4kafka/controller/NamespaceControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/NamespaceControllerTest.java
@@ -18,7 +18,6 @@
  */
 package com.michelin.ns4kafka.controller;
 
-import static com.michelin.ns4kafka.security.auth.JwtCustomClaimNames.ROLE_BINDINGS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;


### PR DESCRIPTION
## Context
The `GET /api/namespaces` endpoint was previously restricted to admin users only. This prevented regular authenticated users (including those using tools like **kafkactl** or **MCP**) from listing the namespaces .

## Proposed solution
The `GET /api/namespaces` endpoint is now accessible to any authenticated user.
When called:

- If the caller is an **Admin or Non Admin**, all namespaces are returned.


The `POST /api/namespaces` and `DELETE /api/namespaces` endpoints remain restricted to administrators.

## Implementation
**NamespaceController**: Removed the class-level `@RolesAllowed(IS_ADMIN)` annotation.
- `GET /api/namespaces`: Now annotated with `@Secured(IS_AUTHENTICATED)`.
- `POST /api/namespaces` & `DELETE /api/namespaces`: Retain `@RolesAllowed(IS_ADMIN)` at method-level to maintain admin-only access for write operations.

**Tests**: Updated to cover both admin and non-admin scenarios for listing namespace endpoint.
