### PR TITLE
Optimize topic import API

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controller/topic/TopicController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/topic/TopicController.java
@@ -106,6 +106,10 @@ public class TopicController extends NamespacedResourceController {
     @Get("/{topic}")
     @Deprecated(since = "1.12.0")
     public Optional<Topic> get(String namespace, String topic) {
+        if (!topicService.isNamespaceOwnerOfTopic(namespace, topic)) {
+            throw new ResourceValidationException(TOPIC, topic, invalidOwner(topic));
+        }
+
         return topicService.findByName(getNamespace(namespace), topic);
     }
 
@@ -123,19 +127,19 @@ public class TopicController extends NamespacedResourceController {
             throws InterruptedException, ExecutionException, TimeoutException {
         Namespace ns = getNamespace(namespace);
 
+        List<String> validationErrors = new ArrayList<>();
+        if (!topicService.isNamespaceOwnerOfTopic(namespace, topic.getMetadata().getName())) {
+            validationErrors.add(invalidOwner(topic.getMetadata().getName()));
+        }
+
+        if (ns.getSpec().getTopicValidator() != null) {
+            validationErrors.addAll(ns.getSpec().getTopicValidator().validate(topic));
+        }
+
         Optional<Topic> existingTopic =
                 topicService.findByName(ns, topic.getMetadata().getName());
 
-        List<String> validationErrors = ns.getSpec().getTopicValidator() != null
-                ? ns.getSpec().getTopicValidator().validate(topic)
-                : new ArrayList<>();
-
         if (existingTopic.isEmpty()) {
-            if (!topicService.isNamespaceOwnerOfTopic(
-                    namespace, topic.getMetadata().getName())) {
-                validationErrors.add(invalidOwner(topic.getMetadata().getName()));
-            }
-
             // Topic names with a period ('.') or underscore ('_') could collide
             List<String> collidingTopics = topicService.findCollidingTopics(ns, topic);
             if (!collidingTopics.isEmpty()) {

--- a/src/main/java/com/michelin/ns4kafka/repository/TopicRepository.java
+++ b/src/main/java/com/michelin/ns4kafka/repository/TopicRepository.java
@@ -20,6 +20,7 @@ package com.michelin.ns4kafka.repository;
 
 import com.michelin.ns4kafka.model.Topic;
 import java.util.List;
+import java.util.Optional;
 
 /** Topic repository. */
 public interface TopicRepository {
@@ -37,6 +38,15 @@ public interface TopicRepository {
      * @return The list of topics
      */
     List<Topic> findAllForCluster(String cluster);
+
+    /**
+     * Find a topic by name and cluster.
+     *
+     * @param cluster The cluster
+     * @param name The topic name
+     * @return An optional topic
+     */
+    Optional<Topic> findByName(String cluster, String name);
 
     /**
      * Create a given topic.

--- a/src/main/java/com/michelin/ns4kafka/service/TopicService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/TopicService.java
@@ -42,7 +42,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -107,13 +106,11 @@ public class TopicService {
      * Find a topic by namespace and name.
      *
      * @param namespace The namespace
-     * @param topic The topic name
+     * @param topicName The topic name
      * @return An optional topic
      */
-    public Optional<Topic> findByName(Namespace namespace, String topic) {
-        return findAllForNamespace(namespace).stream()
-                .filter(t -> t.getMetadata().getName().equals(topic))
-                .findFirst();
+    public Optional<Topic> findByName(Namespace namespace, String topicName) {
+        return topicRepository.findByName(namespace.getMetadata().getCluster(), topicName);
     }
 
     /**
@@ -274,14 +271,9 @@ public class TopicService {
         List<AccessControlEntry> acls =
                 aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC);
 
-        Set<String> ns4KafkaTopicNames =
-                topicRepository.findAllForCluster(namespace.getMetadata().getCluster()).stream()
-                        .map(topic -> topic.getMetadata().getName())
-                        .collect(Collectors.toSet());
-
         return topicAsyncExecutor
                 .collectBrokerTopicsFromNames(topicAsyncExecutor.listBrokerTopicNames().stream()
-                        .filter(topic -> !ns4KafkaTopicNames.contains(topic)
+                        .filter(topic -> findByName(namespace, topic).isEmpty()
                                 && aclService.isResourceCoveredByAcls(acls, topic)
                                 && RegexUtils.isResourceCoveredByRegex(topic, nameFilterPatterns))
                         .toList())

--- a/src/test/java/com/michelin/ns4kafka/controller/TopicControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/TopicControllerTest.java
@@ -134,17 +134,10 @@ class TopicControllerTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    void shouldGetTopicWhenEmpty() {
-        Namespace ns = Namespace.builder()
-                .metadata(Metadata.builder().name("test").cluster("local").build())
-                .build();
+    void shouldGetTopicWhenNotOwner() {
+        when(topicService.isNamespaceOwnerOfTopic(any(), any())).thenReturn(false);
 
-        when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
-        when(topicService.findByName(ns, "topic.notfound")).thenReturn(Optional.empty());
-
-        Optional<Topic> actual = topicController.get("test", "topic.notfound");
-
-        assertTrue(actual.isEmpty());
+        assertThrows(ResourceValidationException.class, () -> topicController.get("test", "topic.notfound"));
     }
 
     @Test
@@ -154,6 +147,7 @@ class TopicControllerTest {
                 .metadata(Metadata.builder().name("test").cluster("local").build())
                 .build();
 
+        when(topicService.isNamespaceOwnerOfTopic(any(), any())).thenReturn(true);
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(topicService.findByName(ns, "topic.found"))
                 .thenReturn(Optional.of(Topic.builder()
@@ -383,6 +377,7 @@ class TopicControllerTest {
                         .build())
                 .build();
 
+        when(topicService.isNamespaceOwnerOfTopic(any(), any())).thenReturn(true);
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(topicService.findByName(ns, "test.topic")).thenReturn(Optional.of(existing));
         when(topicService.create(topic)).thenReturn(topic);
@@ -427,6 +422,7 @@ class TopicControllerTest {
                         .build())
                 .build();
 
+        when(topicService.isNamespaceOwnerOfTopic(any(), any())).thenReturn(true);
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(topicService.findByName(ns, "test.topic")).thenReturn(Optional.of(existing));
         when(topicService.validateTags(ns, topic)).thenReturn(List.of("Error on tags"));
@@ -468,6 +464,7 @@ class TopicControllerTest {
                         .build())
                 .build();
 
+        when(topicService.isNamespaceOwnerOfTopic(any(), any())).thenReturn(true);
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(topicService.findByName(ns, "test.topic")).thenReturn(Optional.of(existing));
         when(topicService.create(topic)).thenReturn(topic);
@@ -512,6 +509,7 @@ class TopicControllerTest {
                         .build())
                 .build();
 
+        when(topicService.isNamespaceOwnerOfTopic(any(), any())).thenReturn(true);
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(topicService.findByName(ns, "test.topic")).thenReturn(Optional.of(existing));
         when(topicService.validateTopicUpdate(ns, existing, topic))
@@ -558,6 +556,7 @@ class TopicControllerTest {
                         .build())
                 .build();
 
+        when(topicService.isNamespaceOwnerOfTopic(any(), any())).thenReturn(true);
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(topicService.findByName(ns, "test.topic")).thenReturn(Optional.of(existing));
 

--- a/src/test/java/com/michelin/ns4kafka/integration/ExceptionHandlerIntegrationTest.java
+++ b/src/test/java/com/michelin/ns4kafka/integration/ExceptionHandlerIntegrationTest.java
@@ -304,7 +304,7 @@ class ExceptionHandlerIntegrationTest extends KafkaIntegrationTest {
 
     @Test
     void shouldNotFoundTopic() {
-        HttpRequest<?> request = HttpRequest.create(HttpMethod.GET, "/api/namespaces/ns1/topics/not-found-topic")
+        HttpRequest<?> request = HttpRequest.create(HttpMethod.GET, "/api/namespaces/ns1/topics/ns1-not-found-topic")
                 .bearerAuth(token);
 
         BlockingHttpClient blockingClient = ns4KafkaClient.toBlocking();

--- a/src/test/java/com/michelin/ns4kafka/service/TopicServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/TopicServiceTest.java
@@ -43,7 +43,6 @@ import io.micronaut.inject.qualifiers.Qualifiers;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
@@ -59,9 +58,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class TopicServiceTest {
-    @InjectMocks
-    TopicService topicService;
-
     @Mock
     AclService aclService;
 
@@ -77,6 +73,9 @@ class TopicServiceTest {
     @Mock
     List<ManagedClusterProperties> managedClusterProperties;
 
+    @InjectMocks
+    TopicService topicService;
+
     @Test
     void shouldFindByName() {
         Namespace ns = Namespace.builder()
@@ -86,50 +85,17 @@ class TopicServiceTest {
                         .build())
                 .build();
 
-        Topic t1 = Topic.builder()
-                .metadata(Metadata.builder().name("ns-topic1").build())
+        Topic topic = Topic.builder()
+                .metadata(Metadata.builder()
+                        .namespace("namespace")
+                        .name("ns-topic1")
+                        .build())
                 .build();
 
-        Topic t2 = Topic.builder()
-                .metadata(Metadata.builder().name("ns-topic2").build())
-                .build();
+        when(topicRepository.findByName(any(), any())).thenReturn(Optional.of(topic));
 
-        Topic t3 = Topic.builder()
-                .metadata(Metadata.builder().name("ns1-topic1").build())
-                .build();
-
-        when(topicRepository.findAllForCluster("local")).thenReturn(List.of(t1, t2, t3));
-        when(aclService.findResourceOwnerGrantedToNamespace(ns, AccessControlEntry.ResourceType.TOPIC))
-                .thenReturn(List.of(
-                        AccessControlEntry.builder()
-                                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                                        .permission(AccessControlEntry.Permission.OWNER)
-                                        .grantedTo("namespace")
-                                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
-                                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
-                                        .resource("ns-")
-                                        .build())
-                                .build(),
-                        AccessControlEntry.builder()
-                                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                                        .permission(AccessControlEntry.Permission.OWNER)
-                                        .grantedTo("namespace")
-                                        .resourcePatternType(AccessControlEntry.ResourcePatternType.LITERAL)
-                                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
-                                        .resource("ns1-topic1")
-                                        .build())
-                                .build()));
-        when(aclService.isResourceCoveredByAcls(any(), anyString())).thenReturn(true);
-
-        // search topic by name
         Optional<Topic> actualTopicPrefixed = topicService.findByName(ns, "ns-topic1");
-        assertEquals(actualTopicPrefixed.orElse(Topic.builder().build()), t1);
-
-        Optional<Topic> actualTopicLiteral = topicService.findByName(ns, "ns1-topic1");
-        assertEquals(actualTopicLiteral.orElse(Topic.builder().build()), t3);
-
-        Optional<Topic> actualTopicNotFound = topicService.findByName(ns, "ns2-topic1");
-        assertThrows(NoSuchElementException.class, actualTopicNotFound::get, "No value present");
+        assertEquals(actualTopicPrefixed.orElse(Topic.builder().build()), topic);
     }
 
     @Test
@@ -896,9 +862,11 @@ class TopicServiceTest {
                         t1.getMetadata().getName(),
                         t2.getMetadata().getName(),
                         t3.getMetadata().getName()));
-        when(topicRepository.findAllForCluster("local")).thenReturn(List.of(t2));
+        when(topicRepository.findByName(any(), any())).thenReturn(Optional.empty());
         when(aclService.isResourceCoveredByAcls(acls, t1.getMetadata().getName()))
                 .thenReturn(true);
+        when(aclService.isResourceCoveredByAcls(acls, t2.getMetadata().getName()))
+                .thenReturn(false);
         when(aclService.isResourceCoveredByAcls(acls, t3.getMetadata().getName()))
                 .thenReturn(false);
         when(topicAsyncExecutor.collectBrokerTopicsFromNames(
@@ -947,7 +915,6 @@ class TopicServiceTest {
                         t1.getMetadata().getName(),
                         t2.getMetadata().getName(),
                         t3.getMetadata().getName()));
-        when(topicRepository.findAllForCluster("local")).thenReturn(List.of());
         when(aclService.isResourceCoveredByAcls(acls, t1.getMetadata().getName()))
                 .thenReturn(false);
         when(aclService.isResourceCoveredByAcls(acls, t2.getMetadata().getName()))


### PR DESCRIPTION
## Implementation proposal
- Initialize and use the "topic OWNER" ACLs list instead of `isNamespaceOwnerOfTopic` for each topic (which iterates over all ACLs to find the namespace ACLs)
- Use `Set` for Ns4kafka topics to have O(1) lookup, instead of `findByName()` for each namespace topic (which iterates on the namespace topics list until the topic is found)
- Regroup all the filters in one method to have a smaller number of topics retrieved from the AdminClient with name parameter filter