### PR TITLE
Add `RegexPattern` validator with lenient/strict mode and warning propagation

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controller/connect/ConnectorController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/connect/ConnectorController.java
@@ -48,6 +48,7 @@ import io.micronaut.security.utils.SecurityService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -138,10 +139,12 @@ public class ConnectorController extends NamespacedResourceController {
         connector.getSpec().getConfig().put("name", connector.getMetadata().getName());
 
         // Validate locally
-        return connectorService.validateLocally(ns, connector).flatMap(validationErrors -> {
-            if (!validationErrors.isEmpty()) {
-                return Mono.error(new ResourceValidationException(connector, validationErrors));
+        return connectorService.validateLocally(ns, connector).flatMap(localResult -> {
+            if (localResult.hasErrors()) {
+                return Mono.error(new ResourceValidationException(connector, localResult.errors()));
             }
+
+            List<String> warnings = new ArrayList<>(localResult.warnings());
 
             // Validate against connect rest API /validate
             return connectorService.validateRemotely(ns, connector).flatMap(remoteValidationErrors -> {
@@ -160,7 +163,7 @@ public class ConnectorController extends NamespacedResourceController {
                 Optional<Connector> existingConnector =
                         connectorService.findByName(ns, connector.getMetadata().getName());
                 if (existingConnector.isPresent() && existingConnector.get().equals(connector)) {
-                    return Mono.just(formatHttpResponse(existingConnector.get(), ApplyStatus.UNCHANGED));
+                    return Mono.just(formatHttpResponse(existingConnector.get(), ApplyStatus.UNCHANGED, warnings));
                 }
 
                 ApplyStatus status = existingConnector.isPresent() ? ApplyStatus.CHANGED : ApplyStatus.CREATED;
@@ -174,7 +177,7 @@ public class ConnectorController extends NamespacedResourceController {
                 }
 
                 if (dryrun) {
-                    return Mono.just(formatHttpResponse(connector, status));
+                    return Mono.just(formatHttpResponse(connector, status, warnings));
                 }
 
                 // Set a toDeploy flag
@@ -188,7 +191,7 @@ public class ConnectorController extends NamespacedResourceController {
                         connector.getSpec(),
                         EMPTY_STRING);
 
-                return Mono.just(formatHttpResponse(connectorService.createOrUpdate(connector), status));
+                return Mono.just(formatHttpResponse(connectorService.createOrUpdate(connector), status, warnings));
             });
         });
     }

--- a/src/main/java/com/michelin/ns4kafka/controller/generic/ResourceController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/generic/ResourceController.java
@@ -29,13 +29,14 @@ import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.security.utils.SecurityService;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
 /** Resource controller. */
 public abstract class ResourceController {
     private static final String STATUS_HEADER = "X-Ns4kafka-Result";
-    static final String WARNING_HEADER = "X-Ns4kafka-Warnings";
+    private static final String WARNING_HEADER = "X-Ns4kafka-Warnings";
     protected final SecurityService securityService;
     protected final ApplicationEventPublisher<AuditLog> applicationEventPublisher;
 
@@ -60,7 +61,7 @@ public abstract class ResourceController {
      * @param <T> The type of the response body
      */
     public <T> HttpResponse<T> formatHttpResponse(T body, ApplyStatus status) {
-        return HttpResponse.ok(body).header(STATUS_HEADER, status.toString());
+        return formatHttpResponse(body, status, Collections.emptyList());
     }
 
     /**
@@ -72,7 +73,7 @@ public abstract class ResourceController {
      *
      * @param body The response body
      * @param status The operation status
-     * @param warnings The list of soft-validation warnings (may be empty)
+     * @param warnings The list of soft-validation warnings (maybe empty)
      * @return The formatted HTTP response
      * @param <T> The type of the response body
      */

--- a/src/main/java/com/michelin/ns4kafka/controller/generic/ResourceController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/generic/ResourceController.java
@@ -26,13 +26,16 @@ import com.michelin.ns4kafka.security.ResourceBasedSecurityRule;
 import com.michelin.ns4kafka.util.enumation.ApplyStatus;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.security.utils.SecurityService;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 
 /** Resource controller. */
 public abstract class ResourceController {
     private static final String STATUS_HEADER = "X-Ns4kafka-Result";
+    static final String WARNING_HEADER = "X-Ns4kafka-Warnings";
     protected final SecurityService securityService;
     protected final ApplicationEventPublisher<AuditLog> applicationEventPublisher;
 
@@ -58,6 +61,27 @@ public abstract class ResourceController {
      */
     public <T> HttpResponse<T> formatHttpResponse(T body, ApplyStatus status) {
         return HttpResponse.ok(body).header(STATUS_HEADER, status.toString());
+    }
+
+    /**
+     * Format an HTTP response with the operation status and optional validation warnings.
+     *
+     * <p>When {@code warnings} is non-empty each warning message is joined with {@code ", "} and emitted in the
+     * {@value WARNING_HEADER} response header so clients (e.g. Kafkactl) can surface them without blocking the
+     * operation.
+     *
+     * @param body The response body
+     * @param status The operation status
+     * @param warnings The list of soft-validation warnings (may be empty)
+     * @return The formatted HTTP response
+     * @param <T> The type of the response body
+     */
+    public <T> HttpResponse<T> formatHttpResponse(T body, ApplyStatus status, List<String> warnings) {
+        MutableHttpResponse<T> response = HttpResponse.ok(body).header(STATUS_HEADER, status.toString());
+        if (warnings != null && !warnings.isEmpty()) {
+            response.header(WARNING_HEADER, String.join(", ", warnings));
+        }
+        return response;
     }
 
     /**

--- a/src/main/java/com/michelin/ns4kafka/controller/topic/TopicController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/topic/TopicController.java
@@ -34,6 +34,7 @@ import com.michelin.ns4kafka.service.ResourceQuotaService;
 import com.michelin.ns4kafka.service.TopicService;
 import com.michelin.ns4kafka.util.enumation.ApplyStatus;
 import com.michelin.ns4kafka.util.exception.ResourceValidationException;
+import com.michelin.ns4kafka.validation.ValidationResult;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Body;
@@ -128,12 +129,16 @@ public class TopicController extends NamespacedResourceController {
         Namespace ns = getNamespace(namespace);
 
         List<String> validationErrors = new ArrayList<>();
+        List<String> validationWarnings = new ArrayList<>();
+
         if (!topicService.isNamespaceOwnerOfTopic(namespace, topic.getMetadata().getName())) {
             validationErrors.add(invalidOwner(topic.getMetadata().getName()));
         }
 
         if (ns.getSpec().getTopicValidator() != null) {
-            validationErrors.addAll(ns.getSpec().getTopicValidator().validate(topic));
+            ValidationResult validationResult = ns.getSpec().getTopicValidator().validate(topic);
+            validationErrors.addAll(validationResult.errors());
+            validationWarnings.addAll(validationResult.warnings());
         }
 
         Optional<Topic> existingTopic =
@@ -170,7 +175,7 @@ public class TopicController extends NamespacedResourceController {
         topic.setStatus(Topic.TopicStatus.ofPending());
 
         if (existingTopic.isPresent() && existingTopic.get().equals(topic)) {
-            return formatHttpResponse(existingTopic.get(), ApplyStatus.UNCHANGED);
+            return formatHttpResponse(existingTopic.get(), ApplyStatus.UNCHANGED, validationWarnings);
         }
 
         validationErrors.addAll(resourceQuotaService.validateTopicQuota(ns, existingTopic, topic));
@@ -180,13 +185,13 @@ public class TopicController extends NamespacedResourceController {
 
         ApplyStatus status = existingTopic.isPresent() ? ApplyStatus.CHANGED : ApplyStatus.CREATED;
         if (dryrun) {
-            return formatHttpResponse(topic, status);
+            return formatHttpResponse(topic, status, validationWarnings);
         }
 
         sendEventLog(
                 topic, status, existingTopic.<Object>map(Topic::getSpec).orElse(null), topic.getSpec(), EMPTY_STRING);
 
-        return formatHttpResponse(topicService.create(topic), status);
+        return formatHttpResponse(topicService.create(topic), status, validationWarnings);
     }
 
     /**

--- a/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
@@ -32,12 +32,12 @@ import com.michelin.ns4kafka.service.client.connect.entities.ConnectorSpecs;
 import com.michelin.ns4kafka.service.executor.ConnectorAsyncExecutor;
 import com.michelin.ns4kafka.util.FormatErrorUtils;
 import com.michelin.ns4kafka.util.RegexUtils;
+import com.michelin.ns4kafka.validation.ValidationResult;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import jakarta.inject.Singleton;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -140,9 +140,9 @@ public class ConnectorService {
      *
      * @param namespace The namespace
      * @param connector The connector to validate
-     * @return A list of errors
+     * @return A {@link ValidationResult} with hard errors and soft warnings
      */
-    public Mono<List<String>> validateLocally(Namespace namespace, Connector connector) {
+    public Mono<ValidationResult> validateLocally(Namespace namespace, Connector connector) {
         // Check whether target Connect Cluster is allowed for this namespace
         List<String> selfDeployedConnectClusters =
                 connectClusterService.findAllForNamespaceWithWritePermission(namespace).stream()
@@ -157,13 +157,13 @@ public class ConnectorService {
             String allowedConnectClusters = Stream.concat(
                             namespace.getSpec().getConnectClusters().stream(), selfDeployedConnectClusters.stream())
                     .collect(Collectors.joining(", "));
-            return Mono.just(List.of(
-                    invalidConnectorConnectCluster(connector.getSpec().getConnectCluster(), allowedConnectClusters)));
+            return Mono.just(ValidationResult.ofErrors(List.of(
+                    invalidConnectorConnectCluster(connector.getSpec().getConnectCluster(), allowedConnectClusters))));
         }
 
         // If class does not exist, no need to go further
         if (StringUtils.isEmpty(connector.getSpec().getConfig().get(CONNECTOR_CLASS))) {
-            return Mono.just(List.of(invalidConnectorEmptyConnectorClass()));
+            return Mono.just(ValidationResult.ofErrors(List.of(invalidConnectorEmptyConnectorClass())));
         }
 
         // Connector type exists on this target connect cluster
@@ -181,13 +181,13 @@ public class ConnectorService {
                             .findFirst();
 
                     if (connectorType.isEmpty()) {
-                        return List.of(invalidConnectorNoPlugin(
-                                connector.getSpec().getConfig().get(CONNECTOR_CLASS)));
+                        return ValidationResult.ofErrors(List.of(invalidConnectorNoPlugin(
+                                connector.getSpec().getConfig().get(CONNECTOR_CLASS))));
                     }
 
                     return namespace.getSpec().getConnectValidator() != null
                             ? namespace.getSpec().getConnectValidator().validate(connector, connectorType.get())
-                            : Collections.emptyList();
+                            : ValidationResult.empty();
                 });
     }
 

--- a/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
+++ b/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
@@ -454,8 +454,7 @@ public class FormatErrorUtils {
      * @param regex the expected regular expression
      * @return the error message
      */
-    public static String invalidFieldValidationRegex(
-            String invalidFieldName, String invalidFieldValue, String regex) {
+    public static String invalidFieldValidationRegex(String invalidFieldName, String invalidFieldValue, String regex) {
         return INVALID_FIELD.formatted(
                 invalidFieldValue, invalidFieldName, "value must match regex \"%s\"".formatted(regex));
     }

--- a/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
+++ b/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
@@ -447,6 +447,20 @@ public class FormatErrorUtils {
     }
 
     /**
+     * Invalid field must be matched by regex.
+     *
+     * @param invalidFieldName the invalid field name
+     * @param invalidFieldValue the invalid field value
+     * @param regex the expected regular expression
+     * @return the error message
+     */
+    public static String invalidFieldValidationRegex(
+            String invalidFieldName, String invalidFieldValue, String regex) {
+        return INVALID_FIELD.formatted(
+                invalidFieldValue, invalidFieldName, "value must match regex \"%s\"".formatted(regex));
+    }
+
+    /**
      * Invalid field is immutable.
      *
      * @param invalidFieldName the invalid field name

--- a/src/main/java/com/michelin/ns4kafka/validation/ConnectValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ConnectValidator.java
@@ -18,7 +18,9 @@
  */
 package com.michelin.ns4kafka.validation;
 
-import static com.michelin.ns4kafka.util.FormatErrorUtils.*;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidNameEmpty;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidNameLength;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidNameSpecChars;
 import static com.michelin.ns4kafka.util.config.ConnectorConfig.CONNECTOR_CLASS;
 
 import com.fasterxml.jackson.annotation.JsonSetter;

--- a/src/main/java/com/michelin/ns4kafka/validation/ConnectValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ConnectValidator.java
@@ -18,9 +18,7 @@
  */
 package com.michelin.ns4kafka.validation;
 
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidNameEmpty;
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidNameLength;
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidNameSpecChars;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.*;
 import static com.michelin.ns4kafka.util.config.ConnectorConfig.CONNECTOR_CLASS;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -99,76 +97,124 @@ public class ConnectValidator extends ResourceValidator {
         List<String> validationErrors = new ArrayList<>();
         List<String> validationWarnings = new ArrayList<>();
 
-        if (!StringUtils.hasText(connector.getMetadata().getName())) {
+        ValidationResult nameValidation = validateName(connector.getMetadata().getName());
+        if (nameValidation != null) {
+            // Hard error in name (blank / too long / special chars) → stop immediately.
+            if (nameValidation.hasErrors()) {
+                return nameValidation;
+            }
+            // Soft warning from name constraint → accumulate and continue.
+            validationWarnings.addAll(nameValidation.warnings());
+        }
+
+        applyConstraints(validationConstraints, connector, validationErrors, validationWarnings);
+        applyConstraints(getConnectorTypeConstraints(connectorType), connector, validationErrors, validationWarnings);
+        applyConstraints(getClassConstraints(connector), connector, validationErrors, validationWarnings);
+
+        return new ValidationResult(validationErrors, validationWarnings);
+    }
+
+    /**
+     * Validates the name field of a connector's metadata.
+     *
+     * <p>Checks are applied in two phases:
+     *
+     * <ol>
+     *   <li>Blank check — returns immediately with a single hard error if the name is empty/null.
+     *   <li>Structural checks (length &gt; 249, illegal characters) — both are evaluated and returned together if
+     *       either fails, so the caller sees all structural problems at once.
+     *   <li>Constraint check — only evaluated when structural checks pass; honours the
+     *       {@link FieldValidationException#soft soft} flag to route to warnings or errors.
+     * </ol>
+     *
+     * @param name The connector name from {@code connector.getMetadata().getName()}
+     * @return A {@link ValidationResult} wrapping any name-level failures, or {@code null} if the name is valid
+     */
+    private ValidationResult validateName(String name) {
+        if (!StringUtils.hasText(name)) {
             return ValidationResult.ofErrors(List.of(invalidNameEmpty()));
         }
 
-        if (connector.getMetadata().getName().length() > 249) {
-            validationErrors.add(invalidNameLength(connector.getMetadata().getName()));
+        // Collect structural errors together so the caller sees all of them at once.
+        List<String> structuralErrors = new ArrayList<>();
+        if (name.length() > 249) {
+            structuralErrors.add(invalidNameLength(name));
+        }
+        if (!name.matches("[a-zA-Z0-9._-]+")) {
+            structuralErrors.add(invalidNameSpecChars(name));
+        }
+        if (!structuralErrors.isEmpty()) {
+            return ValidationResult.ofErrors(structuralErrors);
         }
 
-        if (!connector.getMetadata().getName().matches("[a-zA-Z0-9._-]+")) {
-            validationErrors.add(invalidNameSpecChars(connector.getMetadata().getName()));
-        }
-
-        validationConstraints.forEach((key, value) -> {
+        // Constraint-based name check — only reached when structural checks pass.
+        if (validationConstraints.containsKey("name")) {
             try {
-                value.ensureValid(key, connector.getSpec().getConfig().get(key));
+                validationConstraints.get("name").ensureValid("name", name);
             } catch (FieldValidationException e) {
                 if (e.soft) {
-                    validationWarnings.add(e.getMessage());
-                } else {
-                    validationErrors.add(e.getMessage());
+                    return ValidationResult.ofWarnings(List.of(e.getMessage()));
                 }
+                return ValidationResult.ofErrors(List.of(e.getMessage()));
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the set of validation constraints that apply to a given connector type.
+     *
+     * <p>Returns {@link #sinkValidationConstraints} for {@code "sink"}, {@link #sourceValidationConstraints} for
+     * {@code "source"}, and an empty map for any unrecognized type — allowing {@link #applyConstraints} to be called
+     * unconditionally at the call site.
+     *
+     * @param connectorType The connector type (e.g. {@code "sink"} or {@code "source"})
+     * @return The corresponding constraint map, or an empty map if the type is unrecognized
+     */
+    private Map<String, Validator> getConnectorTypeConstraints(String connectorType) {
+        return switch (connectorType) {
+            case "sink" -> sinkValidationConstraints;
+            case "source" -> sourceValidationConstraints;
+            default -> Map.of();
+        };
+    }
+
+    /**
+     * Resolves the set of class-specific validation constraints for the given connector.
+     *
+     * <p>Looks up the connector's class name (from {@code connector.getSpec().getConfig().get(CONNECTOR_CLASS)}) in
+     * {@link #classValidationConstraints}. Returns an empty map if no class-specific constraints are registered,
+     * allowing {@link #applyConstraints} to be called unconditionally at the call site.
+     *
+     * @param connector The connector whose class-specific constraints should be resolved
+     * @return The constraint map for the connector's class, or an empty map if none are registered
+     */
+    private Map<String, Validator> getClassConstraints(Connector connector) {
+        String connectorClass = connector.getSpec().getConfig().get(CONNECTOR_CLASS);
+        return classValidationConstraints.getOrDefault(connectorClass, Map.of());
+    }
+
+    /**
+     * Applies a set of validation constraints against a connector's config, routing each outcome to the appropriate
+     * list.
+     *
+     * <p>For each entry in {@code constraints}, calls {@link Validator#ensureValid(String, Object)} with the
+     * corresponding value from the connector's config. Any {@link FieldValidationException} is routed to
+     * {@code warnings} if {@link FieldValidationException#soft soft} is {@code true}, or to {@code errors} otherwise.
+     *
+     * @param constraints The map of config key to {@link Validator} to apply
+     * @param connector The connector whose config values are being validated
+     * @param errors Accumulator for hard validation failures
+     * @param warnings Accumulator for soft validation failures
+     */
+    private void applyConstraints(
+            Map<String, Validator> constraints, Connector connector, List<String> errors, List<String> warnings) {
+        constraints.forEach((key, validator) -> {
+            try {
+                validator.ensureValid(key, connector.getSpec().getConfig().get(key));
+            } catch (FieldValidationException e) {
+                (e.soft ? warnings : errors).add(e.getMessage());
             }
         });
-
-        if (connectorType.equals("sink")) {
-            sinkValidationConstraints.forEach((key, value) -> {
-                try {
-                    value.ensureValid(key, connector.getSpec().getConfig().get(key));
-                } catch (FieldValidationException e) {
-                    if (e.soft) {
-                        validationWarnings.add(e.getMessage());
-                    } else {
-                        validationErrors.add(e.getMessage());
-                    }
-                }
-            });
-        }
-
-        if (connectorType.equals("source")) {
-            sourceValidationConstraints.forEach((key, value) -> {
-                try {
-                    value.ensureValid(key, connector.getSpec().getConfig().get(key));
-                } catch (FieldValidationException e) {
-                    if (e.soft) {
-                        validationWarnings.add(e.getMessage());
-                    } else {
-                        validationErrors.add(e.getMessage());
-                    }
-                }
-            });
-        }
-
-        if (classValidationConstraints.containsKey(
-                connector.getSpec().getConfig().get(CONNECTOR_CLASS))) {
-            classValidationConstraints
-                    .get(connector.getSpec().getConfig().get(CONNECTOR_CLASS))
-                    .forEach((key, value) -> {
-                        try {
-                            value.ensureValid(
-                                    key, connector.getSpec().getConfig().get(key));
-                        } catch (FieldValidationException e) {
-                            if (e.soft) {
-                                validationWarnings.add(e.getMessage());
-                            } else {
-                                validationErrors.add(e.getMessage());
-                            }
-                        }
-                    });
-        }
-
-        return new ValidationResult(validationErrors, validationWarnings);
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/validation/ConnectValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ConnectValidator.java
@@ -88,15 +88,19 @@ public class ConnectValidator extends ResourceValidator {
     /**
      * Validate a given connector.
      *
+     * <p>Hard failures (soft=false) are returned as errors; lenient-mode regex mismatches (soft=true) are returned as
+     * warnings so the resource can still be created while the caller is notified.
+     *
      * @param connector The connector
      * @param connectorType The connector type
-     * @return A list of validation errors
+     * @return A {@link ValidationResult} containing errors and warnings
      */
-    public List<String> validate(Connector connector, String connectorType) {
+    public ValidationResult validate(Connector connector, String connectorType) {
         List<String> validationErrors = new ArrayList<>();
+        List<String> validationWarnings = new ArrayList<>();
 
         if (!StringUtils.hasText(connector.getMetadata().getName())) {
-            return List.of(invalidNameEmpty());
+            return ValidationResult.ofErrors(List.of(invalidNameEmpty()));
         }
 
         if (connector.getMetadata().getName().length() > 249) {
@@ -111,7 +115,11 @@ public class ConnectValidator extends ResourceValidator {
             try {
                 value.ensureValid(key, connector.getSpec().getConfig().get(key));
             } catch (FieldValidationException e) {
-                validationErrors.add(e.getMessage());
+                if (e.soft) {
+                    validationWarnings.add(e.getMessage());
+                } else {
+                    validationErrors.add(e.getMessage());
+                }
             }
         });
 
@@ -120,7 +128,11 @@ public class ConnectValidator extends ResourceValidator {
                 try {
                     value.ensureValid(key, connector.getSpec().getConfig().get(key));
                 } catch (FieldValidationException e) {
-                    validationErrors.add(e.getMessage());
+                    if (e.soft) {
+                        validationWarnings.add(e.getMessage());
+                    } else {
+                        validationErrors.add(e.getMessage());
+                    }
                 }
             });
         }
@@ -130,7 +142,11 @@ public class ConnectValidator extends ResourceValidator {
                 try {
                     value.ensureValid(key, connector.getSpec().getConfig().get(key));
                 } catch (FieldValidationException e) {
-                    validationErrors.add(e.getMessage());
+                    if (e.soft) {
+                        validationWarnings.add(e.getMessage());
+                    } else {
+                        validationErrors.add(e.getMessage());
+                    }
                 }
             });
         }
@@ -144,10 +160,15 @@ public class ConnectValidator extends ResourceValidator {
                             value.ensureValid(
                                     key, connector.getSpec().getConfig().get(key));
                         } catch (FieldValidationException e) {
-                            validationErrors.add(e.getMessage());
+                            if (e.soft) {
+                                validationWarnings.add(e.getMessage());
+                            } else {
+                                validationErrors.add(e.getMessage());
+                            }
                         }
                     });
         }
-        return validationErrors;
+
+        return new ValidationResult(validationErrors, validationWarnings);
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/validation/FieldValidationException.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/FieldValidationException.java
@@ -39,13 +39,11 @@ public class FieldValidationException extends RuntimeException {
      * Constructor.
      *
      * @param error The error message
-     *  @param soft {@code true} if this exception is informational and should be
-     *              surfaced to the user as a warning rather than a hard failure;
-     *              {@code false} if it represents a critical validation error.
+     * @param soft {@code true} if this exception is informational and should be surfaced to the user as a warning
+     *     rather than a hard failure; {@code false} if it represents a critical validation error.
      */
     public FieldValidationException(String error, boolean soft) {
         super(error);
         this.soft = soft;
-
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/validation/FieldValidationException.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/FieldValidationException.java
@@ -25,6 +25,7 @@ public class FieldValidationException extends RuntimeException {
     @Serial
     private static final long serialVersionUID = 6223587833587267232L;
 
+    public boolean soft = false;
     /**
      * Constructor.
      *
@@ -32,5 +33,19 @@ public class FieldValidationException extends RuntimeException {
      */
     public FieldValidationException(String error) {
         super(error);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param error The error message
+     *  @param soft {@code true} if this exception is informational and should be
+     *              surfaced to the user as a warning rather than a hard failure;
+     *              {@code false} if it represents a critical validation error.
+     */
+    public FieldValidationException(String error, boolean soft) {
+        super(error);
+        this.soft = soft;
+
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
@@ -18,15 +18,16 @@
  */
 package com.michelin.ns4kafka.validation;
 
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationNull;
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationNumber;
 import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationAtLeast;
 import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationAtMost;
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationOneOf;
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationEmpty;
 import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationContains;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationEmpty;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationNull;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationNumber;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationOneOf;
 import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationRegex;
 import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
@@ -18,13 +18,7 @@
  */
 package com.michelin.ns4kafka.validation;
 
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationAtLeast;
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationAtMost;
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationContains;
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationEmpty;
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationNull;
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationNumber;
-import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationOneOf;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.*;
 import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -57,6 +51,7 @@ public abstract class ResourceValidator {
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "validation-type")
     @JsonSubTypes({
         @JsonSubTypes.Type(value = Range.class, name = "Range"),
+        @JsonSubTypes.Type(value = RegexPattern.class, name = "RegexPattern"),
         @JsonSubTypes.Type(value = ValidList.class, name = "ValidList"),
         @JsonSubTypes.Type(value = ContainsList.class, name = "ContainsList"),
         @JsonSubTypes.Type(value = ValidString.class, name = "ValidString"),
@@ -335,6 +330,30 @@ public abstract class ResourceValidator {
                         invalidFieldValidationContains(name, value.toString(), String.join(",", mandatoryStrings)));
             }
         }
+    }
+
+    /** Validation logic for a given regex pattern on a string. */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RegexPattern implements Validator {
+        private String regex;
+
+        public static RegexPattern matches(String regex) {
+            return new RegexPattern(regex);
+        }
+
+        @Override
+        public void ensureValid(String name, Object value) {
+            if (value == null) {
+                throw new FieldValidationException(invalidFieldValidationNull(name));
+            }
+            String s = (String) value;
+            if (!s.matches(regex)) {
+                throw new FieldValidationException(invalidFieldValidationRegex(name, value.toString(), regex));
+            }
+        }
+
     }
 
     /** Validation logic for a composite validator. */

--- a/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
@@ -337,12 +337,11 @@ public abstract class ResourceValidator {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RegexPattern implements Validator {
-        public static final List<String> VALID_MODES = List.of("lenient", "strict");
         private String regex;
-        private String mode;
+        private boolean strict = false;
 
-        public static RegexPattern matches(String regex, String mode) {
-            return new RegexPattern(regex, mode);
+        public static RegexPattern matches(String regex, boolean strict) {
+            return new RegexPattern(regex, strict);
         }
 
         @Override
@@ -352,17 +351,13 @@ public abstract class ResourceValidator {
                 // If for some reason the regex pattern is invoked but fields are not set, return.
                 return;
             }
-            if (mode == null || !(VALID_MODES.contains(mode))) {
-                throw new FieldValidationException(
-                        invalidFieldValidationContains("mode", mode, String.join(",", VALID_MODES)));
-            }
+
             if (value == null) {
                 throw new FieldValidationException(invalidFieldValidationNull(name));
             }
             String s = (String) value;
             if (!s.matches(regex)) {
-                throw new FieldValidationException(
-                        invalidFieldValidationRegex(name, value.toString(), regex), "lenient".equals(mode));
+                throw new FieldValidationException(invalidFieldValidationRegex(name, value.toString(), regex), !strict);
             }
         }
     }

--- a/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -337,20 +338,30 @@ public abstract class ResourceValidator {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RegexPattern implements Validator {
+        public static final List<String> VALID_MODES = List.of("lenient", "strict");
         private String regex;
+        private String mode;
 
-        public static RegexPattern matches(String regex) {
-            return new RegexPattern(regex);
+        public static RegexPattern matches(String regex, String mode) {
+            return new RegexPattern(regex, mode);
         }
 
         @Override
         public void ensureValid(String name, Object value) {
+
+            if (regex == null || regex.isEmpty()) {
+                // If for some reason the regex pattern is invoked but fields are not set, return.
+                return;
+            }
+            if (mode == null || !(VALID_MODES.contains(mode))) {
+                throw new FieldValidationException(invalidFieldValidationContains("mode", mode, String.join(",", VALID_MODES)));
+            }
             if (value == null) {
                 throw new FieldValidationException(invalidFieldValidationNull(name));
             }
             String s = (String) value;
             if (!s.matches(regex)) {
-                throw new FieldValidationException(invalidFieldValidationRegex(name, value.toString(), regex));
+                throw new FieldValidationException(invalidFieldValidationRegex(name, value.toString(), regex), "lenient".equals(mode));
             }
         }
 

--- a/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
@@ -18,9 +18,15 @@
  */
 package com.michelin.ns4kafka.validation;
 
-import static com.michelin.ns4kafka.util.FormatErrorUtils.*;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationNull;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationNumber;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationAtLeast;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationAtMost;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationOneOf;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationEmpty;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationContains;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidFieldValidationRegex;
 import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
-
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ResourceValidator.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -354,17 +353,18 @@ public abstract class ResourceValidator {
                 return;
             }
             if (mode == null || !(VALID_MODES.contains(mode))) {
-                throw new FieldValidationException(invalidFieldValidationContains("mode", mode, String.join(",", VALID_MODES)));
+                throw new FieldValidationException(
+                        invalidFieldValidationContains("mode", mode, String.join(",", VALID_MODES)));
             }
             if (value == null) {
                 throw new FieldValidationException(invalidFieldValidationNull(name));
             }
             String s = (String) value;
             if (!s.matches(regex)) {
-                throw new FieldValidationException(invalidFieldValidationRegex(name, value.toString(), regex), "lenient".equals(mode));
+                throw new FieldValidationException(
+                        invalidFieldValidationRegex(name, value.toString(), regex), "lenient".equals(mode));
             }
         }
-
     }
 
     /** Validation logic for a composite validator. */

--- a/src/main/java/com/michelin/ns4kafka/validation/TopicValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/TopicValidator.java
@@ -147,6 +147,17 @@ public class TopicValidator extends ResourceValidator {
             errors.add(invalidNameSpecChars(name));
         }
 
+        if (validationConstraints.containsKey("name")) {
+            try {
+                validationConstraints.get("name").ensureValid("name", name);
+            } catch (FieldValidationException e) {
+                if (e.soft) {
+                    return ValidationResult.ofWarnings(List.of(e.getMessage()));
+                }
+                return ValidationResult.ofErrors(List.of(e.getMessage()));
+            }
+        }
+
         return ValidationResult.ofErrors(errors);
     }
 

--- a/src/main/java/com/michelin/ns4kafka/validation/TopicValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/TopicValidator.java
@@ -32,7 +32,6 @@ import io.micronaut.core.util.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -96,71 +95,130 @@ public class TopicValidator extends ResourceValidator {
                 .build();
     }
 
-    /**
-     * Validate a given topic.
-     *
-     * <p>Hard failures (soft=false) are returned as errors; lenient-mode regex mismatches (soft=true) are returned as
-     * warnings so the resource can still be created while the caller is notified.
-     *
-     * @param topic The topic
-     * @return A {@link ValidationResult} containing errors and warnings
-     * @see <a href=
-     *     "https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/internals/Topic.java#L36">
-     *     GitHub</a>
-     */
     public ValidationResult validate(Topic topic) {
         List<String> validationErrors = new ArrayList<>();
         List<String> validationWarnings = new ArrayList<>();
 
-        if (!StringUtils.hasText(topic.getMetadata().getName())) {
-            validationErrors.add(invalidNameEmpty());
+        ValidationResult nameResult = validateName(topic.getMetadata().getName());
+        validationErrors.addAll(nameResult.errors());
+        validationWarnings.addAll(nameResult.warnings());
+
+        ValidationResult unknownConfigsResult = validateUnknownConfigs(topic);
+        validationErrors.addAll(unknownConfigsResult.errors());
+
+        ValidationResult constraintsResult = applyConstraints(validationConstraints, topic);
+        validationErrors.addAll(constraintsResult.errors());
+        validationWarnings.addAll(constraintsResult.warnings());
+
+        return new ValidationResult(validationErrors, validationWarnings);
+    }
+
+    /**
+     * Validates the name field of a topic's metadata.
+     *
+     * <p>Unlike connector name validation, all structural checks are independent and accumulate — the caller sees every
+     * problem at once. The blank check is the only short-circuit: if the name is empty or null, further checks would be
+     * meaningless and are skipped.
+     *
+     * <p>Checks applied :
+     *
+     * <ol>
+     *   <li>Name must not be {@code "."} or {@code ".."}
+     *   <li>Name must not exceed 249 characters
+     *   <li>Name must only contain {@code [a-zA-Z0-9._-]}
+     * </ol>
+     *
+     * @param name The topic name from {@code topic.getMetadata().getName()}
+     * @return A {@link ValidationResult} containing any name-level errors, empty if the name is valid
+     */
+    private ValidationResult validateName(String name) {
+        List<String> errors = new ArrayList<>();
+
+        if (!StringUtils.hasText(name)) {
+            errors.add(invalidNameEmpty());
+        }
+        if (List.of(".", "..").contains(name)) {
+            errors.add(invalidTopicName(name));
+        }
+        if (name != null && name.length() > 249) {
+            errors.add(invalidNameLength(name));
+        }
+        if (name != null && !name.matches("[a-zA-Z0-9._-]+")) {
+            errors.add(invalidNameSpecChars(name));
         }
 
-        if (List.of(".", "..").contains(topic.getMetadata().getName())) {
-            validationErrors.add(invalidTopicName(topic.getMetadata().getName()));
+        return ValidationResult.ofErrors(errors);
+    }
+
+    /**
+     * Checks that every key in the topic's config is covered by a known validation constraint.
+     *
+     * <p>Any config entry whose key is not present in {@link #validationConstraints} is considered an
+     * unknown/unsupported field and produces a hard error. The check is skipped entirely when
+     * {@link #validationConstraints} is empty or the topic's config map is {@code null}.
+     *
+     * @param topic The topic whose config is being inspected
+     * @return A {@link ValidationResult} containing any unknown-config errors
+     */
+    private ValidationResult validateUnknownConfigs(Topic topic) {
+        if (validationConstraints.isEmpty() || topic.getSpec().getConfigs() == null) {
+            return ValidationResult.empty();
         }
 
-        if (topic.getMetadata().getName().length() > 249) {
-            validationErrors.add(invalidNameLength(topic.getMetadata().getName()));
-        }
+        List<String> errors = topic.getSpec().getConfigs().entrySet().stream()
+                .filter(entry -> !validationConstraints.containsKey(entry.getKey()))
+                .map(entry -> invalidTopicSpec(entry.getKey(), entry.getValue()))
+                .toList();
 
-        if (!topic.getMetadata().getName().matches("[a-zA-Z0-9._-]+")) {
-            validationErrors.add(invalidNameSpecChars(topic.getMetadata().getName()));
-        }
+        return ValidationResult.ofErrors(errors);
+    }
 
-        if (!validationConstraints.isEmpty() && topic.getSpec().getConfigs() != null) {
-            Map<String, String> configsWithoutConstraints = topic.getSpec().getConfigs().entrySet().stream()
-                    .filter(entry -> !validationConstraints.containsKey(entry.getKey()))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    /**
+     * Applies a set of validation constraints against a topic's spec, routing each outcome to the appropriate list.
+     *
+     * <p>The value passed to {@link Validator#ensureValid(String, Object)} depends on the key:
+     *
+     * <ul>
+     *   <li>{@link com.michelin.ns4kafka.util.config.TopicConfig#PARTITIONS PARTITIONS} →
+     *       {@code topic.getSpec().getPartitions()}
+     *   <li>{@link com.michelin.ns4kafka.util.config.TopicConfig#REPLICATION_FACTOR REPLICATION_FACTOR} →
+     *       {@code topic.getSpec().getReplicationFactor()}
+     *   <li>Any other key → the matching entry in {@code topic.getSpec().getConfigs()}; if the config map is
+     *       {@code null}, a hard error is added directly and {@code ensureValid} is not called.
+     * </ul>
+     *
+     * <p>Any {@link FieldValidationException} is routed to warnings if {@link FieldValidationException#soft soft} is
+     * {@code true}, or to errors otherwise.
+     *
+     * @param constraints The map of config key to {@link Validator} to apply
+     * @param topic The topic whose spec values are being validated
+     * @return A {@link ValidationResult} containing any constraint errors and warnings
+     */
+    private ValidationResult applyConstraints(Map<String, Validator> constraints, Topic topic) {
+        List<String> errors = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
 
-            if (!configsWithoutConstraints.isEmpty()) {
-                configsWithoutConstraints.forEach((key, value) -> validationErrors.add(invalidTopicSpec(key, value)));
-            }
-        }
-
-        validationConstraints.forEach((key, value) -> {
+        constraints.forEach((key, validator) -> {
             try {
                 switch (key) {
-                    case PARTITIONS -> value.ensureValid(key, topic.getSpec().getPartitions());
+                    case PARTITIONS ->
+                        validator.ensureValid(key, topic.getSpec().getPartitions());
                     case REPLICATION_FACTOR ->
-                        value.ensureValid(key, topic.getSpec().getReplicationFactor());
+                        validator.ensureValid(key, topic.getSpec().getReplicationFactor());
                     default -> {
-                        if (topic.getSpec().getConfigs() != null) {
-                            value.ensureValid(key, topic.getSpec().getConfigs().get(key));
+                        if (topic.getSpec().getConfigs() == null) {
+                            errors.add(invalidFieldValidationNull(key));
                         } else {
-                            validationErrors.add(invalidFieldValidationNull(key));
+                            validator.ensureValid(
+                                    key, topic.getSpec().getConfigs().get(key));
                         }
                     }
                 }
             } catch (FieldValidationException e) {
-                if (e.soft) {
-                    validationWarnings.add(e.getMessage());
-                } else {
-                    validationErrors.add(e.getMessage());
-                }
+                (e.soft ? warnings : errors).add(e.getMessage());
             }
         });
 
-        return new ValidationResult(validationErrors, validationWarnings);
+        return new ValidationResult(errors, warnings);
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/validation/TopicValidator.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/TopicValidator.java
@@ -99,14 +99,18 @@ public class TopicValidator extends ResourceValidator {
     /**
      * Validate a given topic.
      *
+     * <p>Hard failures (soft=false) are returned as errors; lenient-mode regex mismatches (soft=true) are returned as
+     * warnings so the resource can still be created while the caller is notified.
+     *
      * @param topic The topic
-     * @return A list of validation errors
+     * @return A {@link ValidationResult} containing errors and warnings
      * @see <a href=
      *     "https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/internals/Topic.java#L36">
      *     GitHub</a>
      */
-    public List<String> validate(Topic topic) {
+    public ValidationResult validate(Topic topic) {
         List<String> validationErrors = new ArrayList<>();
+        List<String> validationWarnings = new ArrayList<>();
 
         if (!StringUtils.hasText(topic.getMetadata().getName())) {
             validationErrors.add(invalidNameEmpty());
@@ -149,10 +153,14 @@ public class TopicValidator extends ResourceValidator {
                     }
                 }
             } catch (FieldValidationException e) {
-                validationErrors.add(e.getMessage());
+                if (e.soft) {
+                    validationWarnings.add(e.getMessage());
+                } else {
+                    validationErrors.add(e.getMessage());
+                }
             }
         });
 
-        return validationErrors;
+        return new ValidationResult(validationErrors, validationWarnings);
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/validation/ValidationResult.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ValidationResult.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.ns4kafka.validation;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Holds the outcome of a resource validation pass.
+ *
+ * <p>Errors are hard failures that must block resource creation/update. Warnings are soft failures (e.g. lenient-mode
+ * regex mismatches) that are surfaced to the caller but do not prevent the operation from succeeding.
+ *
+ * <p>The {@code soft} flag on {@link FieldValidationException} drives the routing: {@code soft=true} → warning,
+ * {@code soft=false} → error.
+ */
+public record ValidationResult(List<String> errors, List<String> warnings) {
+
+    /** Convenience factory for a result with no errors and no warnings. */
+    public static ValidationResult empty() {
+        return new ValidationResult(List.of(), List.of());
+    }
+
+    /**
+     * Convenience factory for a result carrying only hard errors and no warnings.
+     *
+     * @param errors the list of hard errors
+     * @return a ValidationResult with the given errors and an empty warnings list
+     */
+    public static ValidationResult ofErrors(List<String> errors) {
+        return new ValidationResult(errors, List.of());
+    }
+
+    /**
+     * Merge this result with another, concatenating both error and warning lists.
+     *
+     * @param other the other ValidationResult to merge
+     * @return a new ValidationResult with the combined errors and warnings
+     */
+    public ValidationResult merge(ValidationResult other) {
+        List<String> mergedErrors =
+                Stream.concat(errors.stream(), other.errors().stream()).toList();
+        List<String> mergedWarnings =
+                Stream.concat(warnings.stream(), other.warnings().stream()).toList();
+        return new ValidationResult(mergedErrors, mergedWarnings);
+    }
+
+    /** Returns {@code true} when there is at least one hard error. */
+    public boolean hasErrors() {
+        return !errors.isEmpty();
+    }
+
+    /** Returns {@code true} when there is at least one soft warning. */
+    public boolean hasWarnings() {
+        return !warnings.isEmpty();
+    }
+}

--- a/src/main/java/com/michelin/ns4kafka/validation/ValidationResult.java
+++ b/src/main/java/com/michelin/ns4kafka/validation/ValidationResult.java
@@ -48,6 +48,16 @@ public record ValidationResult(List<String> errors, List<String> warnings) {
     }
 
     /**
+     * Convenience factory for a result carrying only soft warnings and no hard errors.
+     *
+     * @param warnings the list of warnings
+     * @return a ValidationResult with the given warnings and an empty errors list
+     */
+    public static ValidationResult ofWarnings(List<String> warnings) {
+        return new ValidationResult(List.of(), warnings);
+    }
+
+    /**
      * Merge this result with another, concatenating both error and warning lists.
      *
      * @param other the other ValidationResult to merge

--- a/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
@@ -39,6 +39,7 @@ import com.michelin.ns4kafka.service.ConnectorService;
 import com.michelin.ns4kafka.service.NamespaceService;
 import com.michelin.ns4kafka.service.ResourceQuotaService;
 import com.michelin.ns4kafka.util.exception.ResourceValidationException;
+import com.michelin.ns4kafka.validation.ValidationResult;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -475,7 +476,7 @@ class ConnectorControllerTest {
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(connectorService.isNamespaceOwnerOfConnect(ns, "connect1")).thenReturn(true);
         when(connectorService.validateLocally(ns, connector))
-                .thenReturn(Mono.just(List.of("Local Validation Error 1")));
+                .thenReturn(Mono.just(new ValidationResult(List.of("Local Validation Error 1"), List.of())));
 
         StepVerifier.create(connectorController.apply("test", connector, false))
                 .consumeErrorWith(error -> {
@@ -510,7 +511,7 @@ class ConnectorControllerTest {
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(connectorService.isNamespaceOwnerOfConnect(ns, "connect1")).thenReturn(true);
-        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(List.of()));
+        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(ValidationResult.empty()));
         when(connectorService.validateRemotely(ns, connector))
                 .thenReturn(Mono.just(List.of("Remote Validation Error 1")));
 
@@ -557,7 +558,7 @@ class ConnectorControllerTest {
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(connectorService.isNamespaceOwnerOfConnect(ns, "connect1")).thenReturn(true);
-        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(List.of()));
+        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(ValidationResult.empty()));
         when(connectorService.validateRemotely(ns, connector)).thenReturn(Mono.just(List.of()));
         when(resourceQuotaService.validateConnectorQuota(any())).thenReturn(List.of());
         when(securityService.username()).thenReturn(Optional.of("test-user"));
@@ -592,7 +593,7 @@ class ConnectorControllerTest {
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(connectorService.isNamespaceOwnerOfConnect(ns, "connect1")).thenReturn(true);
-        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(List.of()));
+        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(ValidationResult.empty()));
         when(connectorService.validateRemotely(ns, connector)).thenReturn(Mono.just(List.of()));
         when(resourceQuotaService.validateConnectorQuota(ns)).thenReturn(List.of("Quota error"));
 
@@ -643,7 +644,7 @@ class ConnectorControllerTest {
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(connectorService.isNamespaceOwnerOfConnect(ns, "connect1")).thenReturn(true);
-        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(List.of()));
+        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(ValidationResult.empty()));
         when(connectorService.validateRemotely(ns, connector)).thenReturn(Mono.just(List.of()));
         when(connectorService.findByName(ns, "connect1")).thenReturn(Optional.of(connector));
 
@@ -696,7 +697,7 @@ class ConnectorControllerTest {
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(connectorService.isNamespaceOwnerOfConnect(ns, "connect1")).thenReturn(true);
-        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(List.of()));
+        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(ValidationResult.empty()));
         when(connectorService.validateRemotely(ns, connector)).thenReturn(Mono.just(List.of()));
         when(connectorService.findByName(ns, "connect1")).thenReturn(Optional.of(connectorOld));
         when(securityService.username()).thenReturn(Optional.of("test-user"));
@@ -731,7 +732,7 @@ class ConnectorControllerTest {
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(connectorService.isNamespaceOwnerOfConnect(ns, "connect1")).thenReturn(true);
-        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(List.of()));
+        when(connectorService.validateLocally(ns, connector)).thenReturn(Mono.just(ValidationResult.empty()));
         when(connectorService.validateRemotely(ns, connector)).thenReturn(Mono.just(List.of()));
 
         StepVerifier.create(connectorController.apply("test", connector, true))

--- a/src/test/java/com/michelin/ns4kafka/integration/ConnectorIntegrationTest.java
+++ b/src/test/java/com/michelin/ns4kafka/integration/ConnectorIntegrationTest.java
@@ -21,6 +21,7 @@ package com.michelin.ns4kafka.integration;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.michelin.ns4kafka.integration.TopicIntegrationTest.BearerAccessRefreshToken;
@@ -39,6 +40,7 @@ import com.michelin.ns4kafka.model.RoleBinding.RoleBindingSpec;
 import com.michelin.ns4kafka.model.RoleBinding.Subject;
 import com.michelin.ns4kafka.model.RoleBinding.SubjectType;
 import com.michelin.ns4kafka.model.RoleBinding.Verb;
+import com.michelin.ns4kafka.model.Status;
 import com.michelin.ns4kafka.model.Topic;
 import com.michelin.ns4kafka.model.connect.ChangeConnectorState;
 import com.michelin.ns4kafka.model.connect.Connector;
@@ -49,6 +51,7 @@ import com.michelin.ns4kafka.service.client.connect.entities.ServerInfo;
 import com.michelin.ns4kafka.service.executor.ConnectorAsyncExecutor;
 import com.michelin.ns4kafka.service.executor.TopicAsyncExecutor;
 import com.michelin.ns4kafka.validation.ConnectValidator;
+import com.michelin.ns4kafka.validation.ResourceValidator;
 import com.michelin.ns4kafka.validation.TopicValidator;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.type.Argument;
@@ -616,6 +619,156 @@ class ConnectorIntegrationTest extends KafkaConnectIntegrationTest {
                 .retrieve(HttpRequest.GET("/connectors/ns1-connector-pause-resume/status"), ConnectorStateInfo.class);
 
         assertEquals("RUNNING", actual.connector().getState());
+    }
+
+    @Test
+    void shouldNotCreateConnectorWhenStrictRegexPatternDoesNotMatchName() {
+        Namespace namespace = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns-strict-regex")
+                        .cluster("test-cluster")
+                        .build())
+                .spec(NamespaceSpec.builder()
+                        .kafkaUser("user-strict-regex")
+                        .connectClusters(List.of("test-connect"))
+                        .topicValidator(TopicValidator.makeDefaultOneBroker())
+                        .connectValidator(ConnectValidator.builder()
+                                .validationConstraints(Map.of(
+                                        "name",
+                                        ResourceValidator.RegexPattern.matches("ns-strict-regex-allowed-.*", true)))
+                                .sinkValidationConstraints(Map.of())
+                                .classValidationConstraints(Map.of())
+                                .build())
+                        .build())
+                .build();
+
+        ns4KafkaClient
+                .toBlocking()
+                .exchange(HttpRequest.create(HttpMethod.POST, "/api/namespaces")
+                        .bearerAuth(token)
+                        .body(namespace));
+
+        AccessControlEntry aclConnect = AccessControlEntry.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns-strict-regex-acl")
+                        .namespace("ns-strict-regex")
+                        .build())
+                .spec(AccessControlEntrySpec.builder()
+                        .resourceType(ResourceType.CONNECT)
+                        .resource("ns-strict-regex-")
+                        .resourcePatternType(ResourcePatternType.PREFIXED)
+                        .permission(Permission.OWNER)
+                        .grantedTo("ns-strict-regex")
+                        .build())
+                .build();
+
+        ns4KafkaClient
+                .toBlocking()
+                .exchange(HttpRequest.create(HttpMethod.POST, "/api/namespaces/ns-strict-regex/acls")
+                        .bearerAuth(token)
+                        .body(aclConnect));
+
+        // Connector name matches the ACL prefix but NOT the strict regex → must be rejected
+        Connector connector = Connector.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns-strict-regex-not-allowed")
+                        .namespace("ns-strict-regex")
+                        .build())
+                .spec(Connector.ConnectorSpec.builder()
+                        .connectCluster("test-connect")
+                        .config(Map.of(
+                                "connector.class", "org.apache.kafka.connect.file.FileStreamSinkConnector",
+                                "tasks.max", "1",
+                                "topics", "ns-strict-regex-topic"))
+                        .build())
+                .build();
+
+        HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () -> ns4KafkaClient
+                .toBlocking()
+                .exchange(HttpRequest.create(HttpMethod.POST, "/api/namespaces/ns-strict-regex/connectors")
+                        .bearerAuth(token)
+                        .body(connector)));
+
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, exception.getStatus());
+        assertTrue(exception.getResponse().getBody(Status.class).isPresent());
+        assertTrue(exception.getResponse().getBody(Status.class).get().getDetails().getCauses().stream()
+                .anyMatch(cause -> cause.contains("ns-strict-regex-not-allowed")));
+    }
+
+    @Test
+    void shouldCreateConnectorWithWarningWhenNonStrictRegexPatternDoesNotMatchName() {
+        Namespace namespace = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns-lenient-regex")
+                        .cluster("test-cluster")
+                        .build())
+                .spec(NamespaceSpec.builder()
+                        .kafkaUser("user-lenient-regex")
+                        .connectClusters(List.of("test-connect"))
+                        .topicValidator(TopicValidator.makeDefaultOneBroker())
+                        .connectValidator(ConnectValidator.builder()
+                                .validationConstraints(Map.of(
+                                        "name",
+                                        ResourceValidator.RegexPattern.matches("ns-lenient-regex-allowed-.*", false)))
+                                .sinkValidationConstraints(Map.of())
+                                .classValidationConstraints(Map.of())
+                                .build())
+                        .build())
+                .build();
+
+        ns4KafkaClient
+                .toBlocking()
+                .exchange(HttpRequest.create(HttpMethod.POST, "/api/namespaces")
+                        .bearerAuth(token)
+                        .body(namespace));
+
+        AccessControlEntry aclConnect = AccessControlEntry.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns-lenient-regex-acl")
+                        .namespace("ns-lenient-regex")
+                        .build())
+                .spec(AccessControlEntrySpec.builder()
+                        .resourceType(ResourceType.CONNECT)
+                        .resource("ns-lenient-regex-")
+                        .resourcePatternType(ResourcePatternType.PREFIXED)
+                        .permission(Permission.OWNER)
+                        .grantedTo("ns-lenient-regex")
+                        .build())
+                .build();
+
+        ns4KafkaClient
+                .toBlocking()
+                .exchange(HttpRequest.create(HttpMethod.POST, "/api/namespaces/ns-lenient-regex/acls")
+                        .bearerAuth(token)
+                        .body(aclConnect));
+
+        // Connector name matches the ACL prefix but NOT the non-strict regex → should be created with a warning
+        Connector connector = Connector.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns-lenient-regex-not-allowed")
+                        .namespace("ns-lenient-regex")
+                        .build())
+                .spec(Connector.ConnectorSpec.builder()
+                        .connectCluster("test-connect")
+                        .config(Map.of(
+                                "connector.class", "org.apache.kafka.connect.file.FileStreamSinkConnector",
+                                "tasks.max", "1",
+                                "topics", "ns-lenient-regex-topic"))
+                        .build())
+                .build();
+
+        HttpResponse<Connector> response = ns4KafkaClient
+                .toBlocking()
+                .exchange(
+                        HttpRequest.create(HttpMethod.POST, "/api/namespaces/ns-lenient-regex/connectors")
+                                .bearerAuth(token)
+                                .body(connector),
+                        Connector.class);
+
+        assertEquals(HttpStatus.OK, response.status());
+        assertTrue(response.getHeaders().contains("X-Ns4kafka-Warnings"));
+        assertTrue(response.getHeaders().get("X-Ns4kafka-Warnings").contains("ns-lenient-regex-not-allowed"));
+        assertTrue(response.getHeaders().get("X-Ns4kafka-Warnings").contains("ns-lenient-regex-allowed-.*"));
     }
 
     /** Force synchronization of all connectors synchronously. */

--- a/src/test/java/com/michelin/ns4kafka/model/ConnectValidatorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/model/ConnectValidatorTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.michelin.ns4kafka.model.connect.Connector;
 import com.michelin.ns4kafka.validation.ConnectValidator;
 import com.michelin.ns4kafka.validation.ResourceValidator;
+import com.michelin.ns4kafka.validation.ValidationResult;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -163,9 +164,11 @@ class ConnectValidatorTest {
                 .metadata(Resource.Metadata.builder().build())
                 .build();
 
-        List<String> actual = validator.validate(connector, "sink");
-        assertEquals(1, actual.size());
-        assertEquals("Invalid empty value for field \"name\": value must not be empty.", actual.getFirst());
+        ValidationResult actual = validator.validate(connector, "sink");
+        assertEquals(1, actual.errors().size());
+        assertEquals(
+                "Invalid empty value for field \"name\": value must not be empty.",
+                actual.errors().getFirst());
     }
 
     @Test
@@ -189,22 +192,16 @@ class ConnectValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = validator.validate(connector, "sink");
-        assertEquals(2, actual.size());
+        ValidationResult actual = validator.validate(connector, "sink");
+        String name = connector.getMetadata().getName();
+        assertEquals(2, actual.errors().size());
         assertEquals(
-                "Invalid value \"$thisNameIsDefinitelyToLoooooooooooooooo"
-                        + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
-                        + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
-                        + "oooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
-                        + "ooooooooooooooongToBeAConnectorName$\" for field \"name\": value must not be longer than 249.",
-                actual.getFirst());
+                "Invalid value \"" + name + "\" for field \"name\": value must not be longer than 249.",
+                actual.errors().getFirst());
         assertEquals(
-                "Invalid value \"$thisNameIsDefinitelyToLooooooooooooooooooooooo"
-                        + "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
-                        + "ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo"
-                        + "oooooooooooooooooooooooooooooooooooooooooooooooooooongToBeAConnectorName$\" "
-                        + "for field \"name\": value must only contain ASCII alphanumerics, '.', '_' or '-'.",
-                actual.get(1));
+                "Invalid value \"" + name
+                        + "\" for field \"name\": value must only contain ASCII alphanumerics, '.', '_' or '-'.",
+                actual.errors().get(1));
     }
 
     @Test
@@ -239,8 +236,8 @@ class ConnectValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = validator.validate(connector, "sink");
-        assertTrue(actual.isEmpty());
+        ValidationResult actual = validator.validate(connector, "sink");
+        assertTrue(actual.errors().isEmpty());
     }
 
     @Test
@@ -272,8 +269,8 @@ class ConnectValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = validator.validate(connector, "sink");
-        assertTrue(actual.isEmpty());
+        ValidationResult actual = validator.validate(connector, "sink");
+        assertTrue(actual.errors().isEmpty());
     }
 
     @Test
@@ -291,8 +288,8 @@ class ConnectValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = validator.validate(connector, "sink");
-        assertTrue(actual.isEmpty());
+        ValidationResult actual = validator.validate(connector, "sink");
+        assertTrue(actual.errors().isEmpty());
     }
 
     @Test
@@ -330,8 +327,8 @@ class ConnectValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = validator.validate(connector, "source");
-        assertTrue(actual.isEmpty());
+        ValidationResult actual = validator.validate(connector, "source");
+        assertTrue(actual.errors().isEmpty());
     }
 
     @Test
@@ -368,11 +365,11 @@ class ConnectValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = validator.validate(connector, "source");
-        assertEquals(1, actual.size());
+        ValidationResult actual = validator.validate(connector, "source");
+        assertEquals(1, actual.errors().size());
         assertEquals(
                 "Invalid empty value for field \"producer.override.sasl.jaas.config\": value must not be null.",
-                actual.getFirst());
+                actual.errors().getFirst());
     }
 
     @Test
@@ -409,10 +406,12 @@ class ConnectValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = validator.validate(connector, "sink");
-        assertEquals(2, actual.size());
-        assertTrue(actual.contains(
-                "Invalid empty value for field \"consumer.override.sasl.jaas.config\": value must not be null."));
-        assertTrue(actual.contains("Invalid empty value for field \"db.timezone\": value must not be null."));
+        ValidationResult actual = validator.validate(connector, "sink");
+        assertEquals(2, actual.errors().size());
+        assertTrue(
+                actual.errors()
+                        .contains(
+                                "Invalid empty value for field \"consumer.override.sasl.jaas.config\": value must not be null."));
+        assertTrue(actual.errors().contains("Invalid empty value for field \"db.timezone\": value must not be null."));
     }
 }

--- a/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
@@ -18,11 +18,11 @@
  */
 package com.michelin.ns4kafka.model;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.michelin.ns4kafka.validation.FieldValidationException;
 import com.michelin.ns4kafka.validation.ResourceValidator;

--- a/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
@@ -18,10 +18,7 @@
  */
 package com.michelin.ns4kafka.model;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.michelin.ns4kafka.validation.FieldValidationException;
 import com.michelin.ns4kafka.validation.ResourceValidator;
@@ -200,6 +197,7 @@ class ResourceValidatorTest {
         assertDoesNotThrow(() -> original.ensureValid("k", "d,a,b,c"));
         assertDoesNotThrow(() -> original.ensureValid("k", "a,d,b,c"));
     }
+
     @Test
     void shouldValidateRegexPattern() {
         ResourceValidator.Validator strict = ResourceValidator.RegexPattern.matches("[a-z]+", "strict");
@@ -232,11 +230,15 @@ class ResourceValidatorTest {
         // Lenient mode — null value still throws
         assertThrows(FieldValidationException.class, () -> lenient.ensureValid("k", null));
 
-        // Lenient mode — non-matching value does NOT throw
-        assertDoesNotThrow(() -> lenient.ensureValid("k", "ABC"));
-        assertDoesNotThrow(() -> lenient.ensureValid("k", "123"));
+        // Lenient mode — non-matching value throws a SOFT exception (warning, not a hard failure)
+        FieldValidationException e1 =
+                assertThrows(FieldValidationException.class, () -> lenient.ensureValid("k", "ABC"));
+        assertTrue(e1.soft);
+        FieldValidationException e2 =
+                assertThrows(FieldValidationException.class, () -> lenient.ensureValid("k", "123"));
+        assertTrue(e2.soft);
 
-        // Lenient mode — matching value passes
+        // Lenient mode — matching value passes without exception
         assertDoesNotThrow(() -> lenient.ensureValid("k", "abc"));
     }
 

--- a/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
@@ -18,7 +18,11 @@
  */
 package com.michelin.ns4kafka.model;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.michelin.ns4kafka.validation.FieldValidationException;
 import com.michelin.ns4kafka.validation.ResourceValidator;

--- a/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
@@ -200,22 +200,14 @@ class ResourceValidatorTest {
 
     @Test
     void shouldValidateRegexPattern() {
-        ResourceValidator.Validator strict = ResourceValidator.RegexPattern.matches("[a-z]+", "strict");
-        ResourceValidator.Validator lenient = ResourceValidator.RegexPattern.matches("[a-z]+", "lenient");
-        ResourceValidator.Validator same = ResourceValidator.RegexPattern.matches("[a-z]+", "strict");
-        ResourceValidator.Validator different = ResourceValidator.RegexPattern.matches("[0-9]+", "strict");
+        ResourceValidator.Validator strict = ResourceValidator.RegexPattern.matches("[a-z]+", true);
+        ResourceValidator.Validator lenient = ResourceValidator.RegexPattern.matches("[a-z]+", false);
+        ResourceValidator.Validator same = ResourceValidator.RegexPattern.matches("[a-z]+", true);
+        ResourceValidator.Validator different = ResourceValidator.RegexPattern.matches("[0-9]+", true);
 
         // Test Equals
         assertEquals(strict, same);
         assertNotEquals(strict, different);
-
-        // Invalid mode
-        ResourceValidator.Validator invalidMode = ResourceValidator.RegexPattern.matches("[a-z]+", "invalid");
-        assertThrows(FieldValidationException.class, () -> invalidMode.ensureValid("k", "abc"));
-
-        // Null mode
-        ResourceValidator.Validator nullMode = ResourceValidator.RegexPattern.matches("[a-z]+", null);
-        assertThrows(FieldValidationException.class, () -> nullMode.ensureValid("k", "abc"));
 
         // Strict mode — null value
         assertThrows(FieldValidationException.class, () -> strict.ensureValid("k", null));
@@ -248,7 +240,7 @@ class ResourceValidatorTest {
         assertDoesNotThrow(() -> noRegex.ensureValid("k", null));
         assertDoesNotThrow(() -> noRegex.ensureValid("k", "anything"));
 
-        ResourceValidator.Validator emptyRegex = ResourceValidator.RegexPattern.matches("", "strict");
+        ResourceValidator.Validator emptyRegex = ResourceValidator.RegexPattern.matches("", true);
         assertDoesNotThrow(() -> emptyRegex.ensureValid("k", null));
         assertDoesNotThrow(() -> emptyRegex.ensureValid("k", "anything"));
     }

--- a/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/model/ResourceValidatorTest.java
@@ -200,4 +200,54 @@ class ResourceValidatorTest {
         assertDoesNotThrow(() -> original.ensureValid("k", "d,a,b,c"));
         assertDoesNotThrow(() -> original.ensureValid("k", "a,d,b,c"));
     }
+    @Test
+    void shouldValidateRegexPattern() {
+        ResourceValidator.Validator strict = ResourceValidator.RegexPattern.matches("[a-z]+", "strict");
+        ResourceValidator.Validator lenient = ResourceValidator.RegexPattern.matches("[a-z]+", "lenient");
+        ResourceValidator.Validator same = ResourceValidator.RegexPattern.matches("[a-z]+", "strict");
+        ResourceValidator.Validator different = ResourceValidator.RegexPattern.matches("[0-9]+", "strict");
+
+        // Test Equals
+        assertEquals(strict, same);
+        assertNotEquals(strict, different);
+
+        // Invalid mode
+        ResourceValidator.Validator invalidMode = ResourceValidator.RegexPattern.matches("[a-z]+", "invalid");
+        assertThrows(FieldValidationException.class, () -> invalidMode.ensureValid("k", "abc"));
+
+        // Null mode
+        ResourceValidator.Validator nullMode = ResourceValidator.RegexPattern.matches("[a-z]+", null);
+        assertThrows(FieldValidationException.class, () -> nullMode.ensureValid("k", "abc"));
+
+        // Strict mode — null value
+        assertThrows(FieldValidationException.class, () -> strict.ensureValid("k", null));
+
+        // Strict mode — non-matching value throws
+        assertThrows(FieldValidationException.class, () -> strict.ensureValid("k", "ABC"));
+        assertThrows(FieldValidationException.class, () -> strict.ensureValid("k", "123"));
+
+        // Strict mode — matching value passes
+        assertDoesNotThrow(() -> strict.ensureValid("k", "abc"));
+
+        // Lenient mode — null value still throws
+        assertThrows(FieldValidationException.class, () -> lenient.ensureValid("k", null));
+
+        // Lenient mode — non-matching value does NOT throw
+        assertDoesNotThrow(() -> lenient.ensureValid("k", "ABC"));
+        assertDoesNotThrow(() -> lenient.ensureValid("k", "123"));
+
+        // Lenient mode — matching value passes
+        assertDoesNotThrow(() -> lenient.ensureValid("k", "abc"));
+    }
+
+    @Test
+    void shouldSkipValidationWhenRegexNotSet() {
+        ResourceValidator.Validator noRegex = new ResourceValidator.RegexPattern();
+        assertDoesNotThrow(() -> noRegex.ensureValid("k", null));
+        assertDoesNotThrow(() -> noRegex.ensureValid("k", "anything"));
+
+        ResourceValidator.Validator emptyRegex = ResourceValidator.RegexPattern.matches("", "strict");
+        assertDoesNotThrow(() -> emptyRegex.ensureValid("k", null));
+        assertDoesNotThrow(() -> emptyRegex.ensureValid("k", "anything"));
+    }
 }

--- a/src/test/java/com/michelin/ns4kafka/model/TopicValidatorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/model/TopicValidatorTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.michelin.ns4kafka.validation.ResourceValidator;
 import com.michelin.ns4kafka.validation.TopicValidator;
+import com.michelin.ns4kafka.validation.ValidationResult;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -151,8 +152,8 @@ class TopicValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = topicValidator.validate(success);
-        assertTrue(actual.isEmpty());
+        ValidationResult actual = topicValidator.validate(success);
+        assertTrue(actual.errors().isEmpty());
     }
 
     @Test
@@ -161,7 +162,7 @@ class TopicValidatorTest {
                 TopicValidator.builder().validationConstraints(Map.of()).build();
 
         Topic invalidTopic;
-        List<String> validationErrors;
+        ValidationResult validationErrors;
 
         invalidTopic = Topic.builder()
                 .metadata(Resource.Metadata.builder().name("").build())
@@ -169,12 +170,12 @@ class TopicValidatorTest {
                 .build();
 
         validationErrors = nameValidator.validate(invalidTopic);
-        assertEquals(2, validationErrors.size());
+        assertEquals(2, validationErrors.errors().size());
         assertLinesMatch(
                 List.of(
                         "Invalid empty value for field \"name\": value must not be empty.",
                         "Invalid value \"\" for field \"name\": value must only contain ASCII alphanumerics, '.', '_' or '-'."),
-                validationErrors);
+                validationErrors.errors());
 
         invalidTopic = Topic.builder()
                 .metadata(Resource.Metadata.builder().name(".").build())
@@ -182,7 +183,7 @@ class TopicValidatorTest {
                 .build();
 
         validationErrors = nameValidator.validate(invalidTopic);
-        assertEquals(1, validationErrors.size());
+        assertEquals(1, validationErrors.errors().size());
 
         invalidTopic = Topic.builder()
                 .metadata(Resource.Metadata.builder().name("..").build())
@@ -190,7 +191,7 @@ class TopicValidatorTest {
                 .build();
 
         validationErrors = nameValidator.validate(invalidTopic);
-        assertEquals(1, validationErrors.size());
+        assertEquals(1, validationErrors.errors().size());
 
         invalidTopic = Topic.builder()
                 .metadata(Resource.Metadata.builder().name("A".repeat(260)).build())
@@ -198,7 +199,7 @@ class TopicValidatorTest {
                 .build();
 
         validationErrors = nameValidator.validate(invalidTopic);
-        assertEquals(1, validationErrors.size());
+        assertEquals(1, validationErrors.errors().size());
 
         invalidTopic = Topic.builder()
                 .metadata(Resource.Metadata.builder().name("A B").build())
@@ -206,7 +207,7 @@ class TopicValidatorTest {
                 .build();
 
         validationErrors = nameValidator.validate(invalidTopic);
-        assertEquals(1, validationErrors.size());
+        assertEquals(1, validationErrors.errors().size());
 
         invalidTopic = Topic.builder()
                 .metadata(Resource.Metadata.builder().name("topicname<invalid").build())
@@ -214,7 +215,7 @@ class TopicValidatorTest {
                 .build();
 
         validationErrors = nameValidator.validate(invalidTopic);
-        assertEquals(1, validationErrors.size());
+        assertEquals(1, validationErrors.errors().size());
     }
 
     @Test
@@ -231,8 +232,8 @@ class TopicValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = topicValidator.validate(topic);
-        assertTrue(actual.isEmpty());
+        ValidationResult actual = topicValidator.validate(topic);
+        assertTrue(actual.errors().isEmpty());
     }
 
     @Test
@@ -247,8 +248,8 @@ class TopicValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = topicValidator.validate(topic);
-        assertTrue(actual.isEmpty());
+        ValidationResult actual = topicValidator.validate(topic);
+        assertTrue(actual.errors().isEmpty());
     }
 
     @Test
@@ -275,11 +276,13 @@ class TopicValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = topicValidator.validate(topic);
-        assertEquals(3, actual.size());
-        assertTrue(actual.contains("Invalid empty value for field \"min.insync.replicas\": value must not be null."));
-        assertTrue(actual.contains("Invalid empty value for field \"retention.ms\": value must not be null."));
-        assertTrue(actual.contains("Invalid empty value for field \"cleanup.policy\": value must not be null."));
+        ValidationResult actual = topicValidator.validate(topic);
+        assertEquals(3, actual.errors().size());
+        assertTrue(actual.errors()
+                .contains("Invalid empty value for field \"min.insync.replicas\": value must not be null."));
+        assertTrue(actual.errors().contains("Invalid empty value for field \"retention.ms\": value must not be null."));
+        assertTrue(
+                actual.errors().contains("Invalid empty value for field \"cleanup.policy\": value must not be null."));
     }
 
     @Test
@@ -315,10 +318,10 @@ class TopicValidatorTest {
                         .build())
                 .build();
 
-        List<String> actual = topicValidator.validate(topic);
-        assertEquals(1, actual.size());
+        ValidationResult actual = topicValidator.validate(topic);
+        assertEquals(1, actual.errors().size());
         assertEquals(
                 "Invalid value \"50\" for field \"retention.bytes\": configuration is not allowed on your namespace.",
-                actual.getFirst());
+                actual.errors().getFirst());
     }
 }

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
@@ -20,6 +20,7 @@ package com.michelin.ns4kafka.service;
 
 import static com.michelin.ns4kafka.service.client.connect.entities.ConnectorType.SOURCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -497,10 +498,10 @@ class ConnectorServiceTest {
 
         StepVerifier.create(connectorService.validateLocally(ns, connector))
                 .consumeNextWith(response -> {
-                    assertEquals(1, response.size());
+                    assertEquals(1, response.errors().size());
                     assertEquals(
                             "Invalid value \"wrong\" for field \"connectCluster\": value must be one of \"local-name\".",
-                            response.getFirst());
+                            response.errors().getFirst());
                 })
                 .verifyComplete();
     }
@@ -527,10 +528,10 @@ class ConnectorServiceTest {
 
         StepVerifier.create(connectorService.validateLocally(ns, connector))
                 .consumeNextWith(response -> {
-                    assertEquals(1, response.size());
+                    assertEquals(1, response.errors().size());
                     assertEquals(
                             "Invalid empty value for field \"connector.class\": value must not be null.",
-                            response.getFirst());
+                            response.errors().getFirst());
                 })
                 .verifyComplete();
     }
@@ -559,12 +560,12 @@ class ConnectorServiceTest {
 
         StepVerifier.create(connectorService.validateLocally(ns, connector))
                 .consumeNextWith(response -> {
-                    assertEquals(1, response.size());
+                    assertEquals(1, response.errors().size());
                     assertEquals(
                             "Invalid value \"org.apache.kafka.connect.file.FileStreamSinkConnector\" "
                                     + "for field \"connector.class\": failed to find any class that implements connector and "
                                     + "which name matches org.apache.kafka.connect.file.FileStreamSinkConnector.",
-                            response.getFirst());
+                            response.errors().getFirst());
                 })
                 .verifyComplete();
     }
@@ -601,10 +602,10 @@ class ConnectorServiceTest {
 
         StepVerifier.create(connectorService.validateLocally(ns, connector))
                 .consumeNextWith(response -> {
-                    assertEquals(1, response.size());
+                    assertEquals(1, response.errors().size());
                     assertEquals(
                             "Invalid empty value for field \"missing.field\": value must not be null.",
-                            response.getFirst());
+                            response.errors().getFirst());
                 })
                 .verifyComplete();
     }
@@ -640,7 +641,7 @@ class ConnectorServiceTest {
                         "org.apache.kafka.connect.file.FileStreamSinkConnector", ConnectorType.SINK, "v1"))));
 
         StepVerifier.create(connectorService.validateLocally(ns, connector))
-                .consumeNextWith(response -> assertTrue(response.isEmpty()))
+                .consumeNextWith(response -> assertFalse(response.hasErrors()))
                 .verifyComplete();
     }
 
@@ -669,7 +670,7 @@ class ConnectorServiceTest {
                         "org.apache.kafka.connect.file.FileStreamSinkConnector", ConnectorType.SINK, "v1"))));
 
         StepVerifier.create(connectorService.validateLocally(ns, connector))
-                .consumeNextWith(response -> assertTrue(response.isEmpty()))
+                .consumeNextWith(response -> assertFalse(response.hasErrors()))
                 .verifyComplete();
     }
 
@@ -703,7 +704,7 @@ class ConnectorServiceTest {
                         "org.apache.kafka.connect.file.FileStreamSinkConnector", ConnectorType.SINK, "v1"))));
 
         StepVerifier.create(connectorService.validateLocally(ns, connector))
-                .consumeNextWith(response -> assertTrue(response.isEmpty()))
+                .consumeNextWith(response -> assertFalse(response.hasErrors()))
                 .verifyComplete();
     }
 
@@ -737,7 +738,7 @@ class ConnectorServiceTest {
                         "org.apache.kafka.connect.file.FileStreamSinkConnector", ConnectorType.SINK, "v1"))));
 
         StepVerifier.create(connectorService.validateLocally(ns, connector))
-                .consumeNextWith(response -> assertTrue(response.isEmpty()))
+                .consumeNextWith(response -> assertFalse(response.hasErrors()))
                 .verifyComplete();
     }
 
@@ -777,7 +778,7 @@ class ConnectorServiceTest {
                         "org.apache.kafka.connect.file.FileStreamSinkConnector", ConnectorType.SINK, "v1"))));
 
         StepVerifier.create(connectorService.validateLocally(ns, connector))
-                .consumeNextWith(response -> assertTrue(response.isEmpty()))
+                .consumeNextWith(response -> assertFalse(response.hasErrors()))
                 .verifyComplete();
     }
 


### PR DESCRIPTION
### What

Introduces a new `RegexPattern`(#788) validation constraint and wires a complete
**soft-failure (warning) pipeline** from the validator layer all the way to
the HTTP response, so a misconfigured resource value can be flagged to the
caller without blocking the operation.

---

### Motivation

Previous validators only had two outcomes: **pass** or **hard error** (the
resource is rejected with HTTP 422). There was no way to express a softer
"this looks wrong but we'll allow it" signal. Teams wanted a regex-based
constraint that could run in two modes:

| Strict | Behaviour |
|------|-----------|
| `true` | Value must match the regex; otherwise the resource is **rejected**. |
| `false` | Value must match the regex; a mismatch surfaces a **warning** but the resource is **created/updated**. |

---

### Changes

#### New / modified production code

| File | Change |
|------|--------|
| `ResourceValidator.RegexPattern` | New inner-class validator. Accepts `regex` + `strict` (`true` \| `lenient`). In lenient mode throws `FieldValidationException(msg, soft=true)`; in strict mode throws the same exception with `soft=false`. Short-circuits (no-op) if `regex` is null or empty. |
| `FieldValidationException` | Added `boolean soft` field and a two-arg constructor so callers can mark an exception as a soft/warning failure. |
| `ValidationResult` | New `record` that carries two lists: `errors` (hard failures) and `warnings` (soft failures). Includes factory methods `empty()`, `ofErrors(List)` and a `merge(ValidationResult)` helper. |
| `TopicValidator.validate()` | Return type changed `List<String>` → `ValidationResult`. `FieldValidationException` is now routed: `e.soft == true` → `warnings`, `false` → `errors`. |
| `ConnectValidator.validate()` | Same change as `TopicValidator`, applied to all four constraint maps (global, sink, source, class). Early-exit (empty name) now returns `ValidationResult.ofErrors(...)`. |
| `ConnectorService.validateLocally()` | Return type changed `Mono<List<String>>` → `Mono<ValidationResult>`. Early-exit error paths wrapped in `ValidationResult.ofErrors(...)`. |
| `ResourceController` | Added `X-Ns4kafka-Warnings` header constant and a new overloaded `formatHttpResponse(body, status, warnings)` that sets the header when the warning list is non-empty. |
| `TopicController.apply()` | Splits validator output into `validationErrors` + `validationWarnings`. Only throws `ResourceValidationException` on hard errors. All three success return paths (`UNCHANGED`, dry-run, `CREATED`/`CHANGED`) forward warnings via the new `formatHttpResponse` overload. |
| `ConnectorController.apply()` | Same pattern: uses `localResult.hasErrors()` guard, collects `localResult.warnings()` and passes them to every success response path. |

#### Test updates

| File | Change |
|------|--------|
| `ResourceValidatorTest` | Added `shouldValidateRegexPattern` and `shouldSkipValidationWhenRegexNotSet`. Lenient-mode mismatch tests assert that a `FieldValidationException` **is** thrown and that `e.soft == true`. |
| `TopicValidatorTest` | All `validate()` call sites updated to `ValidationResult`; assertions use `.errors()`. |
| `ConnectValidatorTest` | Same as above. Expected error messages now built from the connector's actual name (avoids brittle string-counting). |
| `ConnectorServiceTest` | `validateLocally()` assertions updated to `.errors().size()` / `.errors().getFirst()`; success assertions use `assertFalse(response.hasErrors())`. |
| `ConnectorControllerTest` | `validateLocally` mocks updated: empty-success → `Mono.just(ValidationResult.empty())`; error case → `Mono.just(new ValidationResult(List.of("…"), List.of()))`. |

---

### How warnings reach the client

```
RegexPattern.ensureValid()  →  FieldValidationException(soft=true)
        ↓
TopicValidator / ConnectValidator.validate()
        catches soft=true  →  ValidationResult.warnings
        ↓
TopicController / ConnectorController.apply()
        no hard errors  →  resource saved
        warnings present  →  formatHttpResponse(…, warnings)
        ↓
HTTP response
  X-Ns4kafka-Result:   created | changed | unchanged
  X-Ns4kafka-Warnings: Invalid value "FOO" for field "bar": value must match regex "…"
```

---

### What has NOT changed

- `validateRemotely()` still returns `Mono<List<String>>` (remote Kafka Connect errors are always hard).
- `ResourceValidationException` still only carries hard errors; it is never thrown for warnings.
- No breaking changes to the existing API response body shape.

### To be done 

- [X] Add suports for X-Ns4kafka-Warning in Kafkactl to display warning when applying ([PR here](https://github.com/michelin/kafkactl/pull/343))