### PR TITLE
Fix every Kafka Connect cluster being synchronized on all clusters

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/service/ConnectClusterService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConnectClusterService.java
@@ -40,8 +40,9 @@ import io.micronaut.core.util.StringUtils;
 import jakarta.inject.Singleton;
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -72,7 +73,7 @@ public class ConnectClusterService {
 
     @Getter
     @Setter
-    private Set<String> healthyConnectClusters = new HashSet<>();
+    private Map<String, Set<String>> healthyConnectClusters = new HashMap<>();
 
     /**
      * Constructor.
@@ -430,8 +431,10 @@ public class ConnectClusterService {
                         ns4KafkaProperties.getSecurity().getAes256EncryptionKey()))
                 .aes256Format(connectCluster.getSpec().getAes256Format())
                 .status(
-                        healthyConnectClusters.contains(
-                                        connectCluster.getMetadata().getName())
+                        healthyConnectClusters
+                                        .getOrDefault(
+                                                connectCluster.getMetadata().getCluster(), Set.of())
+                                        .contains(connectCluster.getMetadata().getName())
                                 ? ConnectCluster.Status.HEALTHY
                                 : ConnectCluster.Status.IDLE);
 

--- a/src/main/java/com/michelin/ns4kafka/service/executor/ConnectorAsyncExecutor.java
+++ b/src/main/java/com/michelin/ns4kafka/service/executor/ConnectorAsyncExecutor.java
@@ -32,8 +32,10 @@ import com.michelin.ns4kafka.util.exception.ResourceValidationException;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import jakarta.inject.Singleton;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
@@ -119,6 +121,7 @@ public class ConnectorAsyncExecutor {
                         connectCluster.getMetadata().getName());
                 connectClusterService
                         .getHealthyConnectClusters()
+                        .computeIfAbsent(managedClusterProperties.getName(), _ -> new HashSet<>())
                         .add(connectCluster.getMetadata().getName());
             } else if (connectCluster.getSpec().getStatus().equals(ConnectCluster.Status.IDLE)) {
                 log.debug(
@@ -127,6 +130,7 @@ public class ConnectorAsyncExecutor {
                         connectCluster.getSpec().getStatusMessage());
                 connectClusterService
                         .getHealthyConnectClusters()
+                        .getOrDefault(managedClusterProperties.getName(), Set.of())
                         .remove(connectCluster.getMetadata().getName());
             }
         });
@@ -134,15 +138,15 @@ public class ConnectorAsyncExecutor {
 
     /** For each connect cluster, start the synchronization of connectors. */
     private Flux<ConnectorInfo> synchronizeConnectors() {
+        Set<String> healthyConnectors =
+                connectClusterService.getHealthyConnectClusters().get(managedClusterProperties.getName());
+
         log.atDebug()
                 .addArgument(managedClusterProperties::getName)
-                .addArgument(
-                        () -> !connectClusterService.getHealthyConnectClusters().isEmpty()
-                                ? String.join(",", connectClusterService.getHealthyConnectClusters())
-                                : "N/A")
+                .addArgument(() -> !healthyConnectors.isEmpty() ? String.join(",", healthyConnectors) : "N/A")
                 .log("Starting connector synchronization for Kafka cluster {}. Healthy Kafka Connects: {}.");
 
-        if (connectClusterService.getHealthyConnectClusters().isEmpty()) {
+        if (healthyConnectors.isEmpty()) {
             log.atDebug()
                     .addArgument(managedClusterProperties::getName)
                     .log("No healthy Kafka Connect for Kafka cluster {}. Skipping synchronization.");
@@ -150,8 +154,7 @@ public class ConnectorAsyncExecutor {
             return Flux.empty();
         }
 
-        return Flux.fromIterable(connectClusterService.getHealthyConnectClusters())
-                .flatMap(this::synchronizeConnectCluster);
+        return Flux.fromIterable(healthyConnectors).flatMap(this::synchronizeConnectCluster);
     }
 
     /**
@@ -168,7 +171,10 @@ public class ConnectorAsyncExecutor {
         return collectBrokerConnectors(connectCluster)
                 .doOnError(error -> {
                     if (error instanceof ResourceValidationException) {
-                        connectClusterService.getHealthyConnectClusters().remove(connectCluster);
+                        connectClusterService
+                                .getHealthyConnectClusters()
+                                .get(managedClusterProperties.getName())
+                                .remove(connectCluster);
                     } else if (error instanceof HttpClientResponseException httpClientResponseException) {
                         log.error(
                                 "Invalid HTTP response {} ({}) during connectors synchronization for Kafka cluster {}"

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectClusterServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectClusterServiceTest.java
@@ -529,7 +529,7 @@ class ConnectClusterServiceTest {
                         .build())
                 .build();
 
-        connectClusterService.setHealthyConnectClusters(Set.of("prefix.connect-cluster"));
+        connectClusterService.setHealthyConnectClusters(Map.of("local", Set.of("prefix.connect-cluster")));
 
         when(connectClusterRepository.findAllForCluster("local")).thenReturn(List.of(connectCluster));
 
@@ -576,7 +576,7 @@ class ConnectClusterServiceTest {
                         .build())
                 .build();
 
-        connectClusterService.setHealthyConnectClusters(Set.of());
+        connectClusterService.setHealthyConnectClusters(Map.of("local", Set.of()));
 
         when(connectClusterRepository.findAllForCluster("local")).thenReturn(List.of(connectCluster));
 


### PR DESCRIPTION
## Context
When using multiple Ns4Kafka clusters, all healthy connect clusters are synchronized for each Ns4Kafka cluster. 

## Example
- 2 Ns4Kafka clusters: `myClusterA` and `myClusterB`
- 3 healthy Kafka Connect clusters: `myConnectClusterA` & `myConnectClusterB` & `myConnectClusterC`
```yaml
---
apiVersion: v1
kind: ConnectCluster
metadata:
  cluster: myClusterA
  name: myConnectClusterA
  namespace: myNamespaceA
```

```yaml
---
apiVersion: v1
kind: ConnectCluster
metadata:
  cluster: myClusterB
  name: myConnectClusterB
  namespace: myNamespaceB
```

```yaml
---
apiVersion: v1
kind: ConnectCluster
metadata:
  cluster: myClusterA
  name: myConnectClusterC
  namespace: myNamespaceC
```

`myConnectClusterA` would be synchronized twice (one on `myClusterA` executor & one on `myClusterB` executor)
`myConnectClusterB` would be synchronized twice (one on `myClusterA` executor & one on `myClusterB` executor)
`myConnectClusterC` would be synchronized twice (one on `myClusterA` executor & one on `myClusterB` executor)

## Proposed solution
- Use `Map` instead of `Set` to store `healthyConnectors` so every healthy connectors are sorted by the "Ns4Kafka cluster".
- Filter on the current Ns4Kafka cluster when checking the healthy Kafka Connect cluster status
