### PR TITLE
Fix reset offset available on non-readable topics

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controller/ConsumerGroupController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/ConsumerGroupController.java
@@ -20,6 +20,7 @@ package com.michelin.ns4kafka.controller;
 
 import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidConsumerGroupDeleteOperation;
 import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidConsumerGroupOperation;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidNamespaceCannotReadTopic;
 import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidOwner;
 import static com.michelin.ns4kafka.util.enumation.Kind.CONSUMER_GROUP;
 import static com.michelin.ns4kafka.util.enumation.Kind.CONSUMER_GROUP_RESET_OFFSET;
@@ -31,6 +32,7 @@ import com.michelin.ns4kafka.model.Namespace;
 import com.michelin.ns4kafka.model.consumer.group.ConsumerGroup;
 import com.michelin.ns4kafka.model.consumer.group.ConsumerGroupResetOffsets;
 import com.michelin.ns4kafka.model.consumer.group.ConsumerGroupResetOffsetsResponse;
+import com.michelin.ns4kafka.service.AclService;
 import com.michelin.ns4kafka.service.ConsumerGroupService;
 import com.michelin.ns4kafka.service.NamespaceService;
 import com.michelin.ns4kafka.util.enumation.ApplyStatus;
@@ -59,21 +61,26 @@ import org.apache.kafka.common.TopicPartition;
 @Controller("/api/namespaces/{namespace}/consumer-groups")
 public class ConsumerGroupController extends NamespacedResourceController {
     private final ConsumerGroupService consumerGroupService;
+    private final AclService aclService;
 
     /**
      * Constructor.
      *
+     * @param consumerGroupService The consumer group service
      * @param namespaceService The namespace service
+     * @param aclService The ACL service
      * @param securityService The security service
      * @param applicationEventPublisher The application event publisher
      */
     public ConsumerGroupController(
             ConsumerGroupService consumerGroupService,
             NamespaceService namespaceService,
+            AclService aclService,
             SecurityService securityService,
             ApplicationEventPublisher<AuditLog> applicationEventPublisher) {
         super(namespaceService, securityService, applicationEventPublisher);
         this.consumerGroupService = consumerGroupService;
+        this.aclService = aclService;
     }
 
     /**
@@ -113,6 +120,12 @@ public class ConsumerGroupController extends NamespacedResourceController {
 
         if (!consumerGroupService.isNamespaceOwnerOfConsumerGroup(namespace, consumerGroup)) {
             validationErrors.add(invalidOwner("group", consumerGroup));
+        }
+
+        if (!aclService.isTopicReadableByNamespace(
+                namespace, consumerGroupResetOffsets.getSpec().getTopic())) {
+            validationErrors.add(invalidNamespaceCannotReadTopic(
+                    consumerGroupResetOffsets.getSpec().getTopic()));
         }
 
         if (!validationErrors.isEmpty()) {

--- a/src/main/java/com/michelin/ns4kafka/service/AclService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/AclService.java
@@ -545,6 +545,31 @@ public class AclService {
     }
 
     /**
+     * Does the namespace have READ ACL on the topic.
+     *
+     * @param namespace The namespace
+     * @param topic The topic name
+     * @return true if it has, false otherwise
+     */
+    public boolean isTopicReadableByNamespace(String namespace, String topic) {
+        return accessControlEntryRepository.findAll().stream()
+                .filter(accessControlEntry ->
+                        accessControlEntry.getSpec().getGrantedTo().equals(namespace))
+                .filter(accessControlEntry -> List.of(
+                                AccessControlEntry.Permission.READ, AccessControlEntry.Permission.OWNER)
+                        .contains(accessControlEntry.getSpec().getPermission()))
+                .filter(accessControlEntry ->
+                        accessControlEntry.getSpec().getResourceType() == AccessControlEntry.ResourceType.TOPIC)
+                .anyMatch(accessControlEntry -> switch (accessControlEntry
+                        .getSpec()
+                        .getResourcePatternType()) {
+                    case PREFIXED ->
+                        topic.startsWith(accessControlEntry.getSpec().getResource());
+                    case LITERAL -> topic.equals(accessControlEntry.getSpec().getResource());
+                });
+    }
+
+    /**
      * Find an ACL by name.
      *
      * @param namespace The namespace

--- a/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
+++ b/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
@@ -544,6 +544,16 @@ public class FormatErrorUtils {
     }
 
     /**
+     * Invalid namespace cannot read the topic.
+     *
+     * @param topic the topic name
+     * @return the error message
+     */
+    public static String invalidNamespaceCannotReadTopic(String topic) {
+        return INVALID_OPERATION.formatted("reset offset", "namespace cannot read topic %s".formatted(topic));
+    }
+
+    /**
      * Invalid name empty.
      *
      * @return the error message

--- a/src/test/java/com/michelin/ns4kafka/controller/ConsumerGroupControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/ConsumerGroupControllerTest.java
@@ -41,6 +41,7 @@ import com.michelin.ns4kafka.model.consumer.group.ConsumerGroupResetOffsets.Cons
 import com.michelin.ns4kafka.model.consumer.group.ConsumerGroupResetOffsets.ResetOffsetsMethod;
 import com.michelin.ns4kafka.model.consumer.group.ConsumerGroupResetOffsetsResponse;
 import com.michelin.ns4kafka.security.ResourceBasedSecurityRule;
+import com.michelin.ns4kafka.service.AclService;
 import com.michelin.ns4kafka.service.ConsumerGroupService;
 import com.michelin.ns4kafka.service.NamespaceService;
 import com.michelin.ns4kafka.util.exception.ResourceValidationException;
@@ -69,6 +70,9 @@ class ConsumerGroupControllerTest {
 
     @Mock
     ConsumerGroupService consumerGroupService;
+
+    @Mock
+    AclService aclService;
 
     @Mock
     ApplicationEventPublisher<AuditLog> applicationEventPublisher;
@@ -133,6 +137,7 @@ class ConsumerGroupControllerTest {
         when(consumerGroupService.validateResetOffsets(resetOffset)).thenReturn(List.of());
         when(consumerGroupService.isNamespaceOwnerOfConsumerGroup("test", "groupID"))
                 .thenReturn(true);
+        when(aclService.isTopicReadableByNamespace("test", "topic1")).thenReturn(true);
         when(consumerGroupService.getConsumerGroupStatus(ns, "groupID")).thenReturn(GroupState.EMPTY);
         when(consumerGroupService.getPartitionsToReset(ns, "groupID", "topic1")).thenReturn(topicPartitions);
         when(consumerGroupService.prepareOffsetsToReset(
@@ -193,6 +198,7 @@ class ConsumerGroupControllerTest {
         when(consumerGroupService.validateResetOffsets(resetOffset)).thenReturn(List.of());
         when(consumerGroupService.isNamespaceOwnerOfConsumerGroup("test", "groupID"))
                 .thenReturn(true);
+        when(aclService.isTopicReadableByNamespace("test", "topic1")).thenReturn(true);
         when(consumerGroupService.getConsumerGroupStatus(ns, "groupID")).thenReturn(GroupState.EMPTY);
         when(consumerGroupService.getPartitionsToReset(ns, "groupID", "topic1")).thenReturn(topicPartitions);
         when(consumerGroupService.prepareOffsetsToReset(
@@ -245,6 +251,7 @@ class ConsumerGroupControllerTest {
         when(consumerGroupService.validateResetOffsets(resetOffset)).thenReturn(List.of());
         when(consumerGroupService.isNamespaceOwnerOfConsumerGroup("test", "groupID"))
                 .thenReturn(true);
+        when(aclService.isTopicReadableByNamespace("test", "topic1")).thenReturn(true);
         when(consumerGroupService.getConsumerGroupStatus(ns, "groupID")).thenReturn(GroupState.EMPTY);
         when(consumerGroupService.getPartitionsToReset(ns, "groupID", "topic1"))
                 .thenThrow(new ExecutionException("Error during getPartitionsToReset", new Throwable()));
@@ -280,6 +287,7 @@ class ConsumerGroupControllerTest {
         when(consumerGroupService.validateResetOffsets(resetOffset)).thenReturn(new ArrayList<>());
         when(consumerGroupService.isNamespaceOwnerOfConsumerGroup("test", "groupID"))
                 .thenReturn(false);
+        when(aclService.isTopicReadableByNamespace("test", "topic1")).thenReturn(true);
 
         ResourceValidationException result = assertThrows(
                 ResourceValidationException.class,
@@ -287,6 +295,41 @@ class ConsumerGroupControllerTest {
 
         assertLinesMatch(
                 List.of("Invalid value \"groupID\" for field \"group\": " + "namespace is not owner of the resource."),
+                result.getValidationErrors());
+    }
+
+    @Test
+    void shouldNotResetConsumerGroupWhenTopicUnreadable() {
+        Namespace ns = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("test")
+                        .cluster("local")
+                        .build())
+                .build();
+
+        ConsumerGroupResetOffsets resetOffset = ConsumerGroupResetOffsets.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("groupID")
+                        .cluster("local")
+                        .build())
+                .spec(ConsumerGroupResetOffsetsSpec.builder()
+                        .topic("topic1")
+                        .method(ResetOffsetsMethod.TO_EARLIEST)
+                        .build())
+                .build();
+
+        when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
+        when(consumerGroupService.validateResetOffsets(resetOffset)).thenReturn(new ArrayList<>());
+        when(consumerGroupService.isNamespaceOwnerOfConsumerGroup("test", "groupID"))
+                .thenReturn(true);
+        when(aclService.isTopicReadableByNamespace("test", "topic1")).thenReturn(false);
+
+        ResourceValidationException result = assertThrows(
+                ResourceValidationException.class,
+                () -> consumerGroupController.resetOffsets("test", "groupID", resetOffset, false));
+
+        assertLinesMatch(
+                List.of("Invalid \"reset offset\" operation: namespace cannot read topic topic1."),
                 result.getValidationErrors());
     }
 
@@ -314,6 +357,7 @@ class ConsumerGroupControllerTest {
         when(consumerGroupService.validateResetOffsets(resetOffset)).thenReturn(List.of("Validation Error"));
         when(consumerGroupService.isNamespaceOwnerOfConsumerGroup("test", "groupID"))
                 .thenReturn(true);
+        when(aclService.isTopicReadableByNamespace("test", "topic1")).thenReturn(true);
 
         ResourceValidationException result = assertThrows(
                 ResourceValidationException.class,
@@ -346,6 +390,7 @@ class ConsumerGroupControllerTest {
         when(consumerGroupService.validateResetOffsets(resetOffset)).thenReturn(new ArrayList<>());
         when(consumerGroupService.isNamespaceOwnerOfConsumerGroup("test", "groupID"))
                 .thenReturn(true);
+        when(aclService.isTopicReadableByNamespace("test", "topic1")).thenReturn(true);
         when(consumerGroupService.getConsumerGroupStatus(ns, "groupID")).thenReturn(GroupState.STABLE);
 
         ResourceValidationException result = assertThrows(

--- a/src/test/java/com/michelin/ns4kafka/service/AclServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/AclServiceTest.java
@@ -1100,6 +1100,47 @@ class AclServiceTest {
     }
 
     @Test
+    void shouldCheckIfTopicReadableForNamespace() {
+        AccessControlEntry aclOwner = AccessControlEntry.builder()
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
+                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
+                        .permission(AccessControlEntry.Permission.OWNER)
+                        .resource("topic1")
+                        .grantedTo("namespace1")
+                        .build())
+                .build();
+
+        AccessControlEntry aclRead = AccessControlEntry.builder()
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
+                        .resourcePatternType(AccessControlEntry.ResourcePatternType.LITERAL)
+                        .permission(AccessControlEntry.Permission.READ)
+                        .resource("topic2")
+                        .grantedTo("namespace2")
+                        .build())
+                .build();
+
+        AccessControlEntry aclWrite = AccessControlEntry.builder()
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
+                        .resourcePatternType(AccessControlEntry.ResourcePatternType.LITERAL)
+                        .permission(AccessControlEntry.Permission.WRITE)
+                        .resource("topic3")
+                        .grantedTo("namespace3")
+                        .build())
+                .build();
+
+        when(accessControlEntryRepository.findAll()).thenReturn(List.of(aclOwner, aclRead, aclWrite));
+
+        assertTrue(aclService.isTopicReadableByNamespace("namespace1", "topic1"));
+        assertTrue(aclService.isTopicReadableByNamespace("namespace2", "topic2"));
+        assertFalse(aclService.isTopicReadableByNamespace("namespace3", "topic3"));
+        assertFalse(aclService.isTopicReadableByNamespace("namespace1", "topic2"));
+        assertFalse(aclService.isTopicReadableByNamespace("namespace1", "topic3"));
+    }
+
+    @Test
     void shouldNotCollideIfDifferentResource() {
         AccessControlEntry aceTopicPrefixedOwner = AccessControlEntry.builder()
                 .spec(AccessControlEntry.AccessControlEntrySpec.builder()


### PR DESCRIPTION
# Proposed solution
- Before resetting offset, check if the namespace has the READ or OWNER ACL on the given topic.
- If not return a validation error (422)