### PR TITLE
Add external consumer groups endpoint for namespace-owned topics

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controller/ConsumerGroupController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/ConsumerGroupController.java
@@ -99,6 +99,21 @@ public class ConsumerGroupController extends NamespacedResourceController {
     }
 
     /**
+     * List external consumer groups consuming topics owned by the namespace, filtered by name parameter.
+     *
+     * @param namespace The namespace
+     * @param name The name parameter
+     * @return The list of external consumer groups
+     * @throws ExecutionException Any execution exception
+     * @throws InterruptedException Any interrupted exception
+     */
+    @Get("/external")
+    public List<ConsumerGroup> listExternal(String namespace, @QueryValue(defaultValue = "*") String name)
+            throws ExecutionException, InterruptedException {
+        return consumerGroupService.findExternalByWildcardName(getNamespace(namespace), name);
+    }
+
+    /**
      * Reset offsets by topic and consumer group.
      *
      * @param namespace The namespace

--- a/src/main/java/com/michelin/ns4kafka/service/ConsumerGroupService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConsumerGroupService.java
@@ -56,16 +56,20 @@ import org.apache.kafka.common.TopicPartition;
 public class ConsumerGroupService {
     private final ApplicationContext applicationContext;
     private final AclService aclService;
+    private final TopicService topicService;
 
     /**
      * Constructor.
      *
      * @param applicationContext The application context
      * @param aclService The ACL service
+     * @param topicService The topic service
      */
-    public ConsumerGroupService(ApplicationContext applicationContext, AclService aclService) {
+    public ConsumerGroupService(
+            ApplicationContext applicationContext, AclService aclService, TopicService topicService) {
         this.applicationContext = applicationContext;
         this.aclService = aclService;
+        this.topicService = topicService;
     }
 
     /**
@@ -82,11 +86,10 @@ public class ConsumerGroupService {
         ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = applicationContext.getBean(
                 ConsumerGroupAsyncExecutor.class,
                 Qualifiers.byName(namespace.getMetadata().getCluster()));
-        List<AccessControlEntry> groupOwnerAcls =
-                aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP);
         List<String> nameFilterPatterns = RegexUtils.convertWildcardStringsToRegex(List.of(name));
         List<String> consumerGroupIds = consumerGroupAsyncExecutor.listConsumerGroupIds().stream()
-                .filter(groupId -> aclService.isResourceCoveredByAcls(groupOwnerAcls, groupId))
+                .filter(groupId ->
+                        isNamespaceOwnerOfConsumerGroup(namespace.getMetadata().getName(), groupId))
                 .filter(groupId -> RegexUtils.isResourceCoveredByRegex(groupId, nameFilterPatterns))
                 .sorted()
                 .toList();
@@ -104,7 +107,7 @@ public class ConsumerGroupService {
                         namespace,
                         groupId,
                         descriptions.get(groupId),
-                        includeOffsets ? getCommittedOffsetsSafely(consumerGroupAsyncExecutor, groupId) : Map.of()))
+                        includeOffsets ? getCommittedOffsets(consumerGroupAsyncExecutor, groupId) : Map.of()))
                 .toList();
     }
 
@@ -122,16 +125,23 @@ public class ConsumerGroupService {
         ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = applicationContext.getBean(
                 ConsumerGroupAsyncExecutor.class,
                 Qualifiers.byName(namespace.getMetadata().getCluster()));
-        List<AccessControlEntry> groupOwnerAcls =
-                aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP);
-        List<AccessControlEntry> topicOwnerAcls =
-                aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC);
         List<String> nameFilterPatterns = RegexUtils.convertWildcardStringsToRegex(List.of(name));
-        List<String> consumerGroupIds = consumerGroupAsyncExecutor.listConsumerGroupIds().stream()
-                .filter(groupId -> RegexUtils.isResourceCoveredByRegex(groupId, nameFilterPatterns))
-                .filter(groupId -> !aclService.isResourceCoveredByAcls(groupOwnerAcls, groupId))
-                .filter(groupId ->
-                        isConsumerGroupOnNamespaceOwnedTopics(consumerGroupAsyncExecutor, topicOwnerAcls, groupId))
+        Map<String, Map<TopicPartition, Long>> committedOffsetsByGroup =
+                consumerGroupAsyncExecutor.listConsumerGroupIds().stream()
+                        .filter(groupId -> RegexUtils.isResourceCoveredByRegex(groupId, nameFilterPatterns))
+                        .filter(groupId -> !isNamespaceOwnerOfConsumerGroup(
+                                namespace.getMetadata().getName(), groupId))
+                        .collect(Collectors.toMap(
+                                groupId -> groupId,
+                                groupId -> getCommittedOffsets(consumerGroupAsyncExecutor, groupId).entrySet().stream()
+                                        .filter(entry -> topicService.isNamespaceOwnerOfTopic(
+                                                namespace.getMetadata().getName(),
+                                                entry.getKey().topic()))
+                                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))));
+
+        List<String> consumerGroupIds = committedOffsetsByGroup.entrySet().stream()
+                .filter(entry -> !entry.getValue().isEmpty())
+                .map(Map.Entry::getKey)
                 .sorted()
                 .toList();
 
@@ -144,10 +154,7 @@ public class ConsumerGroupService {
 
         return consumerGroupIds.stream()
                 .map(groupId -> buildConsumerGroup(
-                        namespace,
-                        groupId,
-                        descriptions.get(groupId),
-                        getCommittedOffsetsSafely(consumerGroupAsyncExecutor, groupId)))
+                        namespace, groupId, descriptions.get(groupId), committedOffsetsByGroup.get(groupId)))
                 .toList();
     }
 
@@ -374,6 +381,15 @@ public class ConsumerGroupService {
         consumerGroupAsyncExecutor.alterConsumerGroupOffsets(consumerGroupId, preparedOffsets);
     }
 
+    /**
+     * Build a consumer group resource.
+     *
+     * @param namespace The namespace
+     * @param consumerGroupId The consumer group
+     * @param description The consumer group description
+     * @param committedOffsets The committed offsets
+     * @return The consumer group
+     */
     private ConsumerGroup buildConsumerGroup(
             Namespace namespace,
             String consumerGroupId,
@@ -400,7 +416,14 @@ public class ConsumerGroupService {
                 .build();
     }
 
-    private Map<TopicPartition, Long> getCommittedOffsetsSafely(
+    /**
+     * Get the committed offsets of a given consumer group.
+     *
+     * @param consumerGroupAsyncExecutor The consumer group async executor
+     * @param groupId The consumer group
+     * @return The committed offsets
+     */
+    private Map<TopicPartition, Long> getCommittedOffsets(
             ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor, String groupId) {
         try {
             return consumerGroupAsyncExecutor.getCommittedOffsets(groupId);
@@ -410,18 +433,5 @@ public class ConsumerGroupService {
             Thread.currentThread().interrupt();
             return Map.of();
         }
-    }
-
-    private boolean isConsumerGroupOnNamespaceOwnedTopics(
-            ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor,
-            List<AccessControlEntry> topicOwnerAcls,
-            String groupId) {
-        if (topicOwnerAcls.isEmpty()) {
-            return false;
-        }
-
-        return getCommittedOffsetsSafely(consumerGroupAsyncExecutor, groupId).keySet().stream()
-                .map(TopicPartition::topic)
-                .anyMatch(topic -> aclService.isResourceCoveredByAcls(topicOwnerAcls, topic));
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/service/ConsumerGroupService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConsumerGroupService.java
@@ -82,14 +82,14 @@ public class ConsumerGroupService {
         ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = applicationContext.getBean(
                 ConsumerGroupAsyncExecutor.class,
                 Qualifiers.byName(namespace.getMetadata().getCluster()));
-        List<AccessControlEntry> ownerAcls =
+        List<AccessControlEntry> groupOwnerAcls =
                 aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP);
         List<String> nameFilterPatterns = RegexUtils.convertWildcardStringsToRegex(List.of(name));
         List<String> consumerGroupIds = consumerGroupAsyncExecutor.listConsumerGroupIds().stream()
-                .filter(groupId -> aclService.isResourceCoveredByAcls(ownerAcls, groupId))
-                .filter(groupId -> RegexUtils.isResourceCoveredByRegex(groupId, nameFilterPatterns))
-                .sorted()
-                .toList();
+            .filter(groupId -> aclService.isResourceCoveredByAcls(groupOwnerAcls, groupId))
+            .filter(groupId -> RegexUtils.isResourceCoveredByRegex(groupId, nameFilterPatterns))
+            .sorted()
+            .toList();
 
         if (consumerGroupIds.isEmpty()) {
             return List.of();
@@ -105,6 +105,49 @@ public class ConsumerGroupService {
                         groupId,
                         descriptions.get(groupId),
                         includeOffsets ? getCommittedOffsetsSafely(consumerGroupAsyncExecutor, groupId) : Map.of()))
+                .toList();
+    }
+
+    /**
+     * Find all external consumer groups consuming topics owned by a given namespace, filtered by name parameter.
+     *
+     * @param namespace The namespace
+     * @param name The name filter
+     * @return A list of external consumer groups
+     * @throws ExecutionException Any execution exception during consumer groups listing
+     * @throws InterruptedException Any interrupted exception during consumer groups listing
+     */
+    public List<ConsumerGroup> findExternalByWildcardName(Namespace namespace, String name)
+            throws ExecutionException, InterruptedException {
+        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = applicationContext.getBean(
+                ConsumerGroupAsyncExecutor.class,
+                Qualifiers.byName(namespace.getMetadata().getCluster()));
+        List<AccessControlEntry> groupOwnerAcls =
+                aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP);
+        List<AccessControlEntry> topicOwnerAcls =
+                aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC);
+        List<String> nameFilterPatterns = RegexUtils.convertWildcardStringsToRegex(List.of(name));
+        List<String> consumerGroupIds = consumerGroupAsyncExecutor.listConsumerGroupIds().stream()
+                .filter(groupId -> RegexUtils.isResourceCoveredByRegex(groupId, nameFilterPatterns))
+                .filter(groupId -> !aclService.isResourceCoveredByAcls(groupOwnerAcls, groupId))
+                .filter(groupId -> isConsumerGroupOnNamespaceOwnedTopics(
+                        consumerGroupAsyncExecutor, topicOwnerAcls, groupId))
+                .sorted()
+                .toList();
+
+        if (consumerGroupIds.isEmpty()) {
+            return List.of();
+        }
+
+        Map<String, ConsumerGroupDescription> descriptions =
+                consumerGroupAsyncExecutor.describeConsumerGroups(consumerGroupIds);
+
+        return consumerGroupIds.stream()
+                .map(groupId -> buildConsumerGroup(
+                        namespace,
+                        groupId,
+                        descriptions.get(groupId),
+                getCommittedOffsetsSafely(consumerGroupAsyncExecutor, groupId)))
                 .toList();
     }
 
@@ -367,5 +410,18 @@ public class ConsumerGroupService {
             Thread.currentThread().interrupt();
             return Map.of();
         }
+    }
+
+    private boolean isConsumerGroupOnNamespaceOwnedTopics(
+            ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor,
+            List<AccessControlEntry> topicOwnerAcls,
+            String groupId) {
+        if (topicOwnerAcls.isEmpty()) {
+            return false;
+        }
+
+        return getCommittedOffsetsSafely(consumerGroupAsyncExecutor, groupId).keySet().stream()
+                .map(TopicPartition::topic)
+                .anyMatch(topic -> aclService.isResourceCoveredByAcls(topicOwnerAcls, topic));
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/service/ConsumerGroupService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConsumerGroupService.java
@@ -86,10 +86,10 @@ public class ConsumerGroupService {
                 aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP);
         List<String> nameFilterPatterns = RegexUtils.convertWildcardStringsToRegex(List.of(name));
         List<String> consumerGroupIds = consumerGroupAsyncExecutor.listConsumerGroupIds().stream()
-            .filter(groupId -> aclService.isResourceCoveredByAcls(groupOwnerAcls, groupId))
-            .filter(groupId -> RegexUtils.isResourceCoveredByRegex(groupId, nameFilterPatterns))
-            .sorted()
-            .toList();
+                .filter(groupId -> aclService.isResourceCoveredByAcls(groupOwnerAcls, groupId))
+                .filter(groupId -> RegexUtils.isResourceCoveredByRegex(groupId, nameFilterPatterns))
+                .sorted()
+                .toList();
 
         if (consumerGroupIds.isEmpty()) {
             return List.of();
@@ -130,8 +130,8 @@ public class ConsumerGroupService {
         List<String> consumerGroupIds = consumerGroupAsyncExecutor.listConsumerGroupIds().stream()
                 .filter(groupId -> RegexUtils.isResourceCoveredByRegex(groupId, nameFilterPatterns))
                 .filter(groupId -> !aclService.isResourceCoveredByAcls(groupOwnerAcls, groupId))
-                .filter(groupId -> isConsumerGroupOnNamespaceOwnedTopics(
-                        consumerGroupAsyncExecutor, topicOwnerAcls, groupId))
+                .filter(groupId ->
+                        isConsumerGroupOnNamespaceOwnedTopics(consumerGroupAsyncExecutor, topicOwnerAcls, groupId))
                 .sorted()
                 .toList();
 
@@ -147,7 +147,7 @@ public class ConsumerGroupService {
                         namespace,
                         groupId,
                         descriptions.get(groupId),
-                getCommittedOffsetsSafely(consumerGroupAsyncExecutor, groupId)))
+                        getCommittedOffsetsSafely(consumerGroupAsyncExecutor, groupId)))
                 .toList();
     }
 

--- a/src/test/java/com/michelin/ns4kafka/controller/ConsumerGroupControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/ConsumerGroupControllerTest.java
@@ -108,8 +108,8 @@ class ConsumerGroupControllerTest {
         assertEquals(expected, consumerGroupController.list("test", "group*"));
     }
 
-        @Test
-        void shouldListExternalConsumerGroups() throws InterruptedException, ExecutionException {
+    @Test
+    void shouldListExternalConsumerGroups() throws InterruptedException, ExecutionException {
         Namespace ns = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
                         .name("test")
@@ -128,8 +128,7 @@ class ConsumerGroupControllerTest {
                 .build());
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
-        when(consumerGroupService.findExternalByWildcardName(ns, "group*"))
-                .thenReturn(expected);
+        when(consumerGroupService.findExternalByWildcardName(ns, "group*")).thenReturn(expected);
 
         assertEquals(expected, consumerGroupController.listExternal("test", "group*"));
     }

--- a/src/test/java/com/michelin/ns4kafka/controller/ConsumerGroupControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/ConsumerGroupControllerTest.java
@@ -108,6 +108,32 @@ class ConsumerGroupControllerTest {
         assertEquals(expected, consumerGroupController.list("test", "group*"));
     }
 
+        @Test
+        void shouldListExternalConsumerGroups() throws InterruptedException, ExecutionException {
+        Namespace ns = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("test")
+                        .cluster("local")
+                        .build())
+                .build();
+        List<ConsumerGroup> expected = List.of(ConsumerGroup.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("foreign-group")
+                        .namespace("test")
+                        .cluster("local")
+                        .build())
+                .status(ConsumerGroup.ConsumerGroupStatus.builder()
+                        .state(GroupState.STABLE)
+                        .build())
+                .build());
+
+        when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
+        when(consumerGroupService.findExternalByWildcardName(ns, "group*"))
+                .thenReturn(expected);
+
+        assertEquals(expected, consumerGroupController.listExternal("test", "group*"));
+    }
+
     @Test
     void shouldResetConsumerGroup() throws InterruptedException, ExecutionException {
         Namespace ns = Namespace.builder()

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
@@ -26,7 +26,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -80,11 +79,14 @@ class ConnectorServiceTest {
     @Mock
     ApplicationContext applicationContext;
 
-    @InjectMocks
-    ConnectorService connectorService;
-
     @Mock
     ConnectClusterService connectClusterService;
+
+    @Mock
+    ConnectorAsyncExecutor connectorAsyncExecutor;
+
+    @InjectMocks
+    ConnectorService connectorService;
 
     @Test
     void shouldListConnectorsWhenEmpty() {
@@ -863,7 +865,6 @@ class ConnectorServiceTest {
                         .build())
                 .build();
 
-        ConnectorAsyncExecutor connectorAsyncExecutor = mock(ConnectorAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConnectorAsyncExecutor.class,
                         Qualifiers.byName(ns.getMetadata().getCluster())))
@@ -964,7 +965,6 @@ class ConnectorServiceTest {
                         .build())
                 .build();
 
-        ConnectorAsyncExecutor connectorAsyncExecutor = mock(ConnectorAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConnectorAsyncExecutor.class,
                         Qualifiers.byName(ns.getMetadata().getCluster())))
@@ -1070,7 +1070,6 @@ class ConnectorServiceTest {
                 .build();
 
         // init connectorAsyncExecutor
-        ConnectorAsyncExecutor connectorAsyncExecutor = mock(ConnectorAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConnectorAsyncExecutor.class,
                         Qualifiers.byName(ns.getMetadata().getCluster())))
@@ -1157,7 +1156,6 @@ class ConnectorServiceTest {
                 .build();
 
         // init connectorAsyncExecutor
-        ConnectorAsyncExecutor connectorAsyncExecutor = mock(ConnectorAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConnectorAsyncExecutor.class,
                         Qualifiers.byName(ns.getMetadata().getCluster())))

--- a/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
@@ -201,8 +201,6 @@ class ConsumerGroupServiceTest {
         when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP))
                 .thenReturn(acls);
         when(aclService.isResourceCoveredByAcls(acls, "namespace-group2")).thenReturn(true);
-        when(aclService.isResourceCoveredByAcls(acls, "namespace-group1")).thenReturn(true);
-        when(aclService.isResourceCoveredByAcls(acls, "other-group")).thenReturn(false);
         when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("namespace-group2")))
                 .thenReturn(Map.of());
         when(consumerGroupAsyncExecutor.getCommittedOffsets("namespace-group2"))
@@ -245,6 +243,173 @@ class ConsumerGroupServiceTest {
         when(aclService.isResourceCoveredByAcls(acls, "other-group")).thenReturn(false);
 
         assertEquals(List.of(), consumerGroupService.findByWildcardName(namespace, "*"));
+    }
+
+        @Test
+        void shouldListExternalConsumerGroupsConsumingNamespaceOwnedTopics()
+                        throws InterruptedException, ExecutionException {
+        Namespace namespace = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("namespace")
+                        .cluster("test")
+                        .build())
+                .build();
+
+        List<AccessControlEntry> groupOwnerAcls = List.of(AccessControlEntry.builder()
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.GROUP)
+                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
+                        .permission(AccessControlEntry.Permission.OWNER)
+                        .grantedTo("namespace")
+                        .resource("namespace-")
+                        .build())
+                .build());
+        List<AccessControlEntry> topicOwnerAcls = List.of(AccessControlEntry.builder()
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
+                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
+                        .permission(AccessControlEntry.Permission.OWNER)
+                        .grantedTo("namespace")
+                        .resource("namespace-")
+                        .build())
+                .build());
+
+        ConsumerGroupDescription stableDescription =
+                new ConsumerGroupDescription(null, true, null, null, null, GroupState.STABLE, null, null, null, null);
+
+        TopicPartition ownedPartition = new TopicPartition("namespace-topic", 0);
+        TopicPartition foreignPartition = new TopicPartition("other-topic", 0);
+
+        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
+        when(applicationContext.getBean(
+                        ConsumerGroupAsyncExecutor.class,
+                        Qualifiers.byName(namespace.getMetadata().getCluster())))
+                .thenReturn(consumerGroupAsyncExecutor);
+        when(consumerGroupAsyncExecutor.listConsumerGroupIds())
+                .thenReturn(List.of("consumer-on-owned-topic", "consumer-on-other-topic", "namespace-owned-group"));
+        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP))
+                .thenReturn(groupOwnerAcls);
+        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC))
+                .thenReturn(topicOwnerAcls);
+        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "consumer-on-owned-topic")).thenReturn(false);
+        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "consumer-on-other-topic")).thenReturn(false);
+        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "namespace-owned-group")).thenReturn(true);
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("consumer-on-owned-topic"))
+                .thenReturn(Map.of(ownedPartition, 5L));
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("consumer-on-other-topic"))
+                .thenReturn(Map.of(foreignPartition, 7L));
+        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic")).thenReturn(true);
+        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "other-topic")).thenReturn(false);
+        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("consumer-on-owned-topic")))
+                .thenReturn(Map.of("consumer-on-owned-topic", stableDescription));
+
+        List<ConsumerGroup> result = consumerGroupService.findExternalByWildcardName(namespace, "*");
+
+        assertEquals(1, result.size());
+        assertEquals("consumer-on-owned-topic", result.getFirst().getMetadata().getName());
+        assertEquals(1, result.getFirst().getStatus().getOffsets().size());
+        assertEquals("namespace-topic", result.getFirst().getStatus().getOffsets().getFirst().getTopic());
+    }
+
+        @Test
+        void shouldIncludeTopicsForMultipleExternalConsumerGroups()
+                        throws InterruptedException, ExecutionException {
+        Namespace namespace = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("namespace")
+                        .cluster("test")
+                        .build())
+                .build();
+
+        List<AccessControlEntry> groupOwnerAcls = List.of(AccessControlEntry.builder()
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.GROUP)
+                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
+                        .permission(AccessControlEntry.Permission.OWNER)
+                        .grantedTo("namespace")
+                        .resource("namespace-")
+                        .build())
+                .build());
+        List<AccessControlEntry> topicOwnerAcls = List.of(AccessControlEntry.builder()
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
+                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
+                        .permission(AccessControlEntry.Permission.OWNER)
+                        .grantedTo("namespace")
+                        .resource("namespace-")
+                        .build())
+                .build());
+
+        ConsumerGroupDescription stableDescription =
+                new ConsumerGroupDescription(null, true, null, null, null, GroupState.STABLE, null, null, null, null);
+
+        TopicPartition firstOwnedPartition = new TopicPartition("namespace-topic", 0);
+        TopicPartition secondOwnedPartition = new TopicPartition("namespace-topic-2", 1);
+
+        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
+        when(applicationContext.getBean(
+                        ConsumerGroupAsyncExecutor.class,
+                        Qualifiers.byName(namespace.getMetadata().getCluster())))
+                .thenReturn(consumerGroupAsyncExecutor);
+        when(consumerGroupAsyncExecutor.listConsumerGroupIds())
+                .thenReturn(List.of("external-group-1", "external-group-2"));
+        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP))
+                .thenReturn(groupOwnerAcls);
+        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC))
+                .thenReturn(topicOwnerAcls);
+        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "external-group-1")).thenReturn(false);
+        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "external-group-2")).thenReturn(false);
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("external-group-1"))
+                .thenReturn(Map.of(firstOwnedPartition, 5L));
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("external-group-2"))
+                .thenReturn(Map.of(secondOwnedPartition, 7L));
+        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic")).thenReturn(true);
+        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic-2")).thenReturn(true);
+        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("external-group-1", "external-group-2")))
+                .thenReturn(Map.of("external-group-1", stableDescription, "external-group-2", stableDescription));
+
+        List<ConsumerGroup> result = consumerGroupService.findExternalByWildcardName(namespace, "*");
+
+        assertEquals(2, result.size());
+        assertEquals("namespace-topic", result.get(0).getStatus().getOffsets().getFirst().getTopic());
+        assertEquals("namespace-topic-2", result.get(1).getStatus().getOffsets().getFirst().getTopic());
+    }
+
+        @Test
+        void shouldNotListExternalConsumerGroupsWhenCommittedOffsetsCannotBeRead()
+                        throws InterruptedException, ExecutionException {
+        Namespace namespace = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("namespace")
+                        .cluster("test")
+                        .build())
+                .build();
+
+        List<AccessControlEntry> topicOwnerAcls = List.of(AccessControlEntry.builder()
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
+                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
+                        .permission(AccessControlEntry.Permission.OWNER)
+                        .grantedTo("namespace")
+                        .resource("namespace-")
+                        .build())
+                .build());
+        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
+        when(applicationContext.getBean(
+                        ConsumerGroupAsyncExecutor.class,
+                        Qualifiers.byName(namespace.getMetadata().getCluster())))
+                .thenReturn(consumerGroupAsyncExecutor);
+        when(consumerGroupAsyncExecutor.listConsumerGroupIds()).thenReturn(List.of("namespace-group1"));
+        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP))
+                .thenReturn(List.of());
+        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC))
+                .thenReturn(topicOwnerAcls);
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("namespace-group1"))
+                .thenThrow(new ExecutionException(new RuntimeException("boom")));
+
+        List<ConsumerGroup> result = consumerGroupService.findExternalByWildcardName(namespace, "*");
+
+        assertTrue(result.isEmpty());
     }
 
     @ParameterizedTest

--- a/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
@@ -245,9 +245,9 @@ class ConsumerGroupServiceTest {
         assertEquals(List.of(), consumerGroupService.findByWildcardName(namespace, "*"));
     }
 
-        @Test
-        void shouldListExternalConsumerGroupsConsumingNamespaceOwnedTopics()
-                        throws InterruptedException, ExecutionException {
+    @Test
+    void shouldListExternalConsumerGroupsConsumingNamespaceOwnedTopics()
+            throws InterruptedException, ExecutionException {
         Namespace namespace = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
                         .name("namespace")
@@ -291,14 +291,18 @@ class ConsumerGroupServiceTest {
                 .thenReturn(groupOwnerAcls);
         when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC))
                 .thenReturn(topicOwnerAcls);
-        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "consumer-on-owned-topic")).thenReturn(false);
-        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "consumer-on-other-topic")).thenReturn(false);
-        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "namespace-owned-group")).thenReturn(true);
+        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "consumer-on-owned-topic"))
+                .thenReturn(false);
+        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "consumer-on-other-topic"))
+                .thenReturn(false);
+        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "namespace-owned-group"))
+                .thenReturn(true);
         when(consumerGroupAsyncExecutor.getCommittedOffsets("consumer-on-owned-topic"))
                 .thenReturn(Map.of(ownedPartition, 5L));
         when(consumerGroupAsyncExecutor.getCommittedOffsets("consumer-on-other-topic"))
                 .thenReturn(Map.of(foreignPartition, 7L));
-        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic")).thenReturn(true);
+        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic"))
+                .thenReturn(true);
         when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "other-topic")).thenReturn(false);
         when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("consumer-on-owned-topic")))
                 .thenReturn(Map.of("consumer-on-owned-topic", stableDescription));
@@ -308,12 +312,13 @@ class ConsumerGroupServiceTest {
         assertEquals(1, result.size());
         assertEquals("consumer-on-owned-topic", result.getFirst().getMetadata().getName());
         assertEquals(1, result.getFirst().getStatus().getOffsets().size());
-        assertEquals("namespace-topic", result.getFirst().getStatus().getOffsets().getFirst().getTopic());
+        assertEquals(
+                "namespace-topic",
+                result.getFirst().getStatus().getOffsets().getFirst().getTopic());
     }
 
-        @Test
-        void shouldIncludeTopicsForMultipleExternalConsumerGroups()
-                        throws InterruptedException, ExecutionException {
+    @Test
+    void shouldIncludeTopicsForMultipleExternalConsumerGroups() throws InterruptedException, ExecutionException {
         Namespace namespace = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
                         .name("namespace")
@@ -357,27 +362,35 @@ class ConsumerGroupServiceTest {
                 .thenReturn(groupOwnerAcls);
         when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC))
                 .thenReturn(topicOwnerAcls);
-        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "external-group-1")).thenReturn(false);
-        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "external-group-2")).thenReturn(false);
+        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "external-group-1"))
+                .thenReturn(false);
+        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "external-group-2"))
+                .thenReturn(false);
         when(consumerGroupAsyncExecutor.getCommittedOffsets("external-group-1"))
                 .thenReturn(Map.of(firstOwnedPartition, 5L));
         when(consumerGroupAsyncExecutor.getCommittedOffsets("external-group-2"))
                 .thenReturn(Map.of(secondOwnedPartition, 7L));
-        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic")).thenReturn(true);
-        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic-2")).thenReturn(true);
+        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic"))
+                .thenReturn(true);
+        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic-2"))
+                .thenReturn(true);
         when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("external-group-1", "external-group-2")))
                 .thenReturn(Map.of("external-group-1", stableDescription, "external-group-2", stableDescription));
 
         List<ConsumerGroup> result = consumerGroupService.findExternalByWildcardName(namespace, "*");
 
         assertEquals(2, result.size());
-        assertEquals("namespace-topic", result.get(0).getStatus().getOffsets().getFirst().getTopic());
-        assertEquals("namespace-topic-2", result.get(1).getStatus().getOffsets().getFirst().getTopic());
+        assertEquals(
+                "namespace-topic",
+                result.get(0).getStatus().getOffsets().getFirst().getTopic());
+        assertEquals(
+                "namespace-topic-2",
+                result.get(1).getStatus().getOffsets().getFirst().getTopic());
     }
 
-        @Test
-        void shouldNotListExternalConsumerGroupsWhenCommittedOffsetsCannotBeRead()
-                        throws InterruptedException, ExecutionException {
+    @Test
+    void shouldNotListExternalConsumerGroupsWhenCommittedOffsetsCannotBeRead()
+            throws InterruptedException, ExecutionException {
         Namespace namespace = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
                         .name("namespace")

--- a/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
@@ -21,7 +21,6 @@ package com.michelin.ns4kafka.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,6 +58,12 @@ class ConsumerGroupServiceTest {
     @Mock
     AclService aclService;
 
+    @Mock
+    TopicService topicService;
+
+    @Mock
+    ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor;
+
     @InjectMocks
     ConsumerGroupService consumerGroupService;
 
@@ -71,54 +76,44 @@ class ConsumerGroupServiceTest {
                         .build())
                 .build();
 
-        List<AccessControlEntry> acls = List.of(AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .resourceType(AccessControlEntry.ResourceType.GROUP)
-                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
-                        .permission(AccessControlEntry.Permission.OWNER)
-                        .grantedTo("namespace")
-                        .resource("namespace-")
-                        .build())
-                .build());
-
         ConsumerGroupDescription stableDescription =
                 new ConsumerGroupDescription(null, true, null, null, null, GroupState.STABLE, null, null, null, null);
 
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
+        TopicPartition partition = new TopicPartition("namespace-topic", 0);
+
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))
                 .thenReturn(consumerGroupAsyncExecutor);
-        when(consumerGroupAsyncExecutor.listConsumerGroupIds())
-                .thenReturn(List.of("other-group", "namespace-group2", "namespace-group1"));
-        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP))
-                .thenReturn(acls);
-        when(aclService.isResourceCoveredByAcls(acls, "other-group")).thenReturn(false);
-        when(aclService.isResourceCoveredByAcls(acls, "namespace-group2")).thenReturn(true);
-        when(aclService.isResourceCoveredByAcls(acls, "namespace-group1")).thenReturn(true);
-        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("namespace-group1", "namespace-group2")))
-                .thenReturn(Map.of("namespace-group1", stableDescription));
+        when(consumerGroupAsyncExecutor.listConsumerGroupIds()).thenReturn(List.of("abc.group1", "def.group2"));
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "abc.group1"))
+                .thenReturn(true);
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "def.group2"))
+                .thenReturn(false);
+        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("abc.group1")))
+                .thenReturn(Map.of("abc.group1", stableDescription));
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("abc.group1")).thenReturn(Map.of(partition, 5L));
 
         List<ConsumerGroup> result = consumerGroupService.findByWildcardName(namespace, "*");
 
-        assertEquals(2, result.size());
+        assertEquals(1, result.size());
 
-        ConsumerGroup firstGroup = result.get(0);
-        assertEquals("namespace-group1", firstGroup.getMetadata().getName());
+        ConsumerGroup firstGroup = result.getFirst();
+        assertEquals("abc.group1", firstGroup.getMetadata().getName());
         assertEquals("namespace", firstGroup.getMetadata().getNamespace());
         assertEquals("test", firstGroup.getMetadata().getCluster());
         assertEquals(GroupState.STABLE, firstGroup.getStatus().getState());
-        assertTrue(firstGroup.getStatus().getOffsets().isEmpty());
+        assertEquals(1, firstGroup.getStatus().getOffsets().size());
 
-        ConsumerGroup secondGroup = result.get(1);
-        assertEquals("namespace-group2", secondGroup.getMetadata().getName());
-        assertEquals(GroupState.UNKNOWN, secondGroup.getStatus().getState());
-        assertTrue(secondGroup.getStatus().getOffsets().isEmpty());
-        verify(consumerGroupAsyncExecutor, never()).getCommittedOffsets(anyString());
+        ConsumerGroup.ConsumerGroupOffset offset =
+                firstGroup.getStatus().getOffsets().getFirst();
+        assertEquals("namespace-topic", offset.getTopic());
+        assertEquals(0, offset.getPartition());
+        assertEquals(5L, offset.getCurrentOffset());
     }
 
     @Test
-    void shouldListConsumerGroupsOwnedByNamespaceWithOffsets() throws InterruptedException, ExecutionException {
+    void shouldListConsumerGroupsOwnedByNamespaceWithoutOffsets() throws InterruptedException, ExecutionException {
         Namespace namespace = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
                         .name("namespace")
@@ -126,50 +121,37 @@ class ConsumerGroupServiceTest {
                         .build())
                 .build();
 
-        List<AccessControlEntry> acls = List.of(AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .resourceType(AccessControlEntry.ResourceType.GROUP)
-                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
-                        .permission(AccessControlEntry.Permission.OWNER)
-                        .grantedTo("namespace")
-                        .resource("namespace-")
-                        .build())
-                .build());
-
         ConsumerGroupDescription stableDescription =
                 new ConsumerGroupDescription(null, true, null, null, null, GroupState.STABLE, null, null, null, null);
 
-        TopicPartition firstPartition = new TopicPartition("topic1", 0);
-        TopicPartition secondPartition = new TopicPartition("topic1", 1);
-        TopicPartition thirdPartition = new TopicPartition("topic2", 0);
-
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))
                 .thenReturn(consumerGroupAsyncExecutor);
-        when(consumerGroupAsyncExecutor.listConsumerGroupIds()).thenReturn(List.of("namespace-group1"));
-        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP))
-                .thenReturn(acls);
-        when(aclService.isResourceCoveredByAcls(acls, "namespace-group1")).thenReturn(true);
-        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("namespace-group1")))
-                .thenReturn(Map.of("namespace-group1", stableDescription));
-        when(consumerGroupAsyncExecutor.getCommittedOffsets("namespace-group1"))
-                .thenReturn(Map.of(thirdPartition, 2L, secondPartition, 7L, firstPartition, 5L));
+        when(consumerGroupAsyncExecutor.listConsumerGroupIds()).thenReturn(List.of("abc.group1", "abc.group2"));
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "abc.group1"))
+                .thenReturn(true);
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "abc.group2"))
+                .thenReturn(true);
+        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("abc.group1", "abc.group2")))
+                .thenReturn(Map.of("abc.group1", stableDescription));
 
         List<ConsumerGroup> result = consumerGroupService.findByWildcardName(namespace, "*");
 
-        assertEquals(1, result.size());
-        assertEquals(3, result.getFirst().getStatus().getOffsets().size());
-        assertEquals("topic1", result.getFirst().getStatus().getOffsets().get(0).getTopic());
-        assertEquals(0, result.getFirst().getStatus().getOffsets().get(0).getPartition());
-        assertEquals(5L, result.getFirst().getStatus().getOffsets().get(0).getCurrentOffset());
-        assertEquals("topic1", result.getFirst().getStatus().getOffsets().get(1).getTopic());
-        assertEquals(1, result.getFirst().getStatus().getOffsets().get(1).getPartition());
-        assertEquals(7L, result.getFirst().getStatus().getOffsets().get(1).getCurrentOffset());
-        assertEquals("topic2", result.getFirst().getStatus().getOffsets().get(2).getTopic());
-        assertEquals(0, result.getFirst().getStatus().getOffsets().get(2).getPartition());
-        assertEquals(2L, result.getFirst().getStatus().getOffsets().get(2).getCurrentOffset());
+        assertEquals(2, result.size());
+
+        ConsumerGroup firstGroup = result.getFirst();
+        assertEquals("abc.group1", firstGroup.getMetadata().getName());
+        assertEquals("namespace", firstGroup.getMetadata().getNamespace());
+        assertEquals("test", firstGroup.getMetadata().getCluster());
+        assertEquals(GroupState.STABLE, firstGroup.getStatus().getState());
+        assertTrue(firstGroup.getStatus().getOffsets().isEmpty());
+
+        ConsumerGroup secondGroup = result.get(1);
+        assertEquals("abc.group2", secondGroup.getMetadata().getName());
+        assertEquals(GroupState.UNKNOWN, secondGroup.getStatus().getState());
+        assertTrue(secondGroup.getStatus().getOffsets().isEmpty());
+        verify(consumerGroupAsyncExecutor, never()).getCommittedOffsets(anyString());
     }
 
     @Test
@@ -181,35 +163,25 @@ class ConsumerGroupServiceTest {
                         .build())
                 .build();
 
-        List<AccessControlEntry> acls = List.of(AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .resourceType(AccessControlEntry.ResourceType.GROUP)
-                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
-                        .permission(AccessControlEntry.Permission.OWNER)
-                        .grantedTo("namespace")
-                        .resource("namespace-")
-                        .build())
-                .build());
-
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))
                 .thenReturn(consumerGroupAsyncExecutor);
         when(consumerGroupAsyncExecutor.listConsumerGroupIds())
-                .thenReturn(List.of("namespace-group2", "namespace-group1", "other-group"));
-        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP))
-                .thenReturn(acls);
-        when(aclService.isResourceCoveredByAcls(acls, "namespace-group2")).thenReturn(true);
-        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("namespace-group2")))
+                .thenReturn(List.of("abc.group1", "abc.group2", "def.other-group"));
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "abc.group1"))
+                .thenReturn(true);
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "abc.group2"))
+                .thenReturn(true);
+        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("abc.group2")))
                 .thenReturn(Map.of());
-        when(consumerGroupAsyncExecutor.getCommittedOffsets("namespace-group2"))
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("abc.group2"))
                 .thenReturn(Map.of(new TopicPartition("topic2", 0), 3L));
 
         List<ConsumerGroup> result = consumerGroupService.findByWildcardName(namespace, "*group2");
 
         assertEquals(1, result.size());
-        assertEquals("namespace-group2", result.getFirst().getMetadata().getName());
+        assertEquals("abc.group2", result.getFirst().getMetadata().getName());
         assertEquals(1, result.getFirst().getStatus().getOffsets().size());
     }
 
@@ -222,32 +194,19 @@ class ConsumerGroupServiceTest {
                         .build())
                 .build();
 
-        List<AccessControlEntry> acls = List.of(AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .resourceType(AccessControlEntry.ResourceType.GROUP)
-                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
-                        .permission(AccessControlEntry.Permission.OWNER)
-                        .grantedTo("namespace")
-                        .resource("namespace-")
-                        .build())
-                .build());
-
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))
                 .thenReturn(consumerGroupAsyncExecutor);
-        when(consumerGroupAsyncExecutor.listConsumerGroupIds()).thenReturn(List.of("other-group"));
-        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP))
-                .thenReturn(acls);
-        when(aclService.isResourceCoveredByAcls(acls, "other-group")).thenReturn(false);
+        when(consumerGroupAsyncExecutor.listConsumerGroupIds()).thenReturn(List.of("abc.group1"));
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "abc.group1"))
+                .thenReturn(false);
 
         assertEquals(List.of(), consumerGroupService.findByWildcardName(namespace, "*"));
     }
 
     @Test
-    void shouldListExternalConsumerGroupsConsumingNamespaceOwnedTopics()
-            throws InterruptedException, ExecutionException {
+    void shouldListExternalConsumerGroups() throws InterruptedException, ExecutionException {
         Namespace namespace = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
                         .name("namespace")
@@ -255,137 +214,45 @@ class ConsumerGroupServiceTest {
                         .build())
                 .build();
 
-        List<AccessControlEntry> groupOwnerAcls = List.of(AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .resourceType(AccessControlEntry.ResourceType.GROUP)
-                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
-                        .permission(AccessControlEntry.Permission.OWNER)
-                        .grantedTo("namespace")
-                        .resource("namespace-")
-                        .build())
-                .build());
-        List<AccessControlEntry> topicOwnerAcls = List.of(AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
-                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
-                        .permission(AccessControlEntry.Permission.OWNER)
-                        .grantedTo("namespace")
-                        .resource("namespace-")
-                        .build())
-                .build());
-
         ConsumerGroupDescription stableDescription =
                 new ConsumerGroupDescription(null, true, null, null, null, GroupState.STABLE, null, null, null, null);
 
-        TopicPartition ownedPartition = new TopicPartition("namespace-topic", 0);
-        TopicPartition foreignPartition = new TopicPartition("other-topic", 0);
+        TopicPartition ownedPartition = new TopicPartition("abc.namespace-topic", 0);
+        TopicPartition ownedGroupForeignPartition = new TopicPartition("ghi.other-topic", 0);
+        TopicPartition foreignPartition = new TopicPartition("def.other-topic", 0);
 
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))
                 .thenReturn(consumerGroupAsyncExecutor);
         when(consumerGroupAsyncExecutor.listConsumerGroupIds())
-                .thenReturn(List.of("consumer-on-owned-topic", "consumer-on-other-topic", "namespace-owned-group"));
-        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP))
-                .thenReturn(groupOwnerAcls);
-        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC))
-                .thenReturn(topicOwnerAcls);
-        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "consumer-on-owned-topic"))
+                .thenReturn(List.of("abc.group1", "def.group1", "def.group2"));
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "def.group1"))
                 .thenReturn(false);
-        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "consumer-on-other-topic"))
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "def.group2"))
                 .thenReturn(false);
-        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "namespace-owned-group"))
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "abc.group1"))
                 .thenReturn(true);
-        when(consumerGroupAsyncExecutor.getCommittedOffsets("consumer-on-owned-topic"))
-                .thenReturn(Map.of(ownedPartition, 5L));
-        when(consumerGroupAsyncExecutor.getCommittedOffsets("consumer-on-other-topic"))
-                .thenReturn(Map.of(foreignPartition, 7L));
-        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic"))
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("def.group1"))
+                .thenReturn(Map.of(ownedPartition, 5L, ownedGroupForeignPartition, 9L));
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("def.group2")).thenReturn(Map.of(foreignPartition, 7L));
+        when(topicService.isNamespaceOwnerOfTopic("namespace", "abc.namespace-topic"))
                 .thenReturn(true);
-        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "other-topic")).thenReturn(false);
-        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("consumer-on-owned-topic")))
-                .thenReturn(Map.of("consumer-on-owned-topic", stableDescription));
+        when(topicService.isNamespaceOwnerOfTopic("namespace", "ghi.other-topic"))
+                .thenReturn(false);
+        when(topicService.isNamespaceOwnerOfTopic("namespace", "def.other-topic"))
+                .thenReturn(false);
+        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("def.group1")))
+                .thenReturn(Map.of("def.group1", stableDescription));
 
         List<ConsumerGroup> result = consumerGroupService.findExternalByWildcardName(namespace, "*");
 
         assertEquals(1, result.size());
-        assertEquals("consumer-on-owned-topic", result.getFirst().getMetadata().getName());
+        assertEquals("def.group1", result.getFirst().getMetadata().getName());
         assertEquals(1, result.getFirst().getStatus().getOffsets().size());
         assertEquals(
-                "namespace-topic",
+                "abc.namespace-topic",
                 result.getFirst().getStatus().getOffsets().getFirst().getTopic());
-    }
-
-    @Test
-    void shouldIncludeTopicsForMultipleExternalConsumerGroups() throws InterruptedException, ExecutionException {
-        Namespace namespace = Namespace.builder()
-                .metadata(Resource.Metadata.builder()
-                        .name("namespace")
-                        .cluster("test")
-                        .build())
-                .build();
-
-        List<AccessControlEntry> groupOwnerAcls = List.of(AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .resourceType(AccessControlEntry.ResourceType.GROUP)
-                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
-                        .permission(AccessControlEntry.Permission.OWNER)
-                        .grantedTo("namespace")
-                        .resource("namespace-")
-                        .build())
-                .build());
-        List<AccessControlEntry> topicOwnerAcls = List.of(AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
-                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
-                        .permission(AccessControlEntry.Permission.OWNER)
-                        .grantedTo("namespace")
-                        .resource("namespace-")
-                        .build())
-                .build());
-
-        ConsumerGroupDescription stableDescription =
-                new ConsumerGroupDescription(null, true, null, null, null, GroupState.STABLE, null, null, null, null);
-
-        TopicPartition firstOwnedPartition = new TopicPartition("namespace-topic", 0);
-        TopicPartition secondOwnedPartition = new TopicPartition("namespace-topic-2", 1);
-
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
-        when(applicationContext.getBean(
-                        ConsumerGroupAsyncExecutor.class,
-                        Qualifiers.byName(namespace.getMetadata().getCluster())))
-                .thenReturn(consumerGroupAsyncExecutor);
-        when(consumerGroupAsyncExecutor.listConsumerGroupIds())
-                .thenReturn(List.of("external-group-1", "external-group-2"));
-        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP))
-                .thenReturn(groupOwnerAcls);
-        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC))
-                .thenReturn(topicOwnerAcls);
-        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "external-group-1"))
-                .thenReturn(false);
-        when(aclService.isResourceCoveredByAcls(groupOwnerAcls, "external-group-2"))
-                .thenReturn(false);
-        when(consumerGroupAsyncExecutor.getCommittedOffsets("external-group-1"))
-                .thenReturn(Map.of(firstOwnedPartition, 5L));
-        when(consumerGroupAsyncExecutor.getCommittedOffsets("external-group-2"))
-                .thenReturn(Map.of(secondOwnedPartition, 7L));
-        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic"))
-                .thenReturn(true);
-        when(aclService.isResourceCoveredByAcls(topicOwnerAcls, "namespace-topic-2"))
-                .thenReturn(true);
-        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("external-group-1", "external-group-2")))
-                .thenReturn(Map.of("external-group-1", stableDescription, "external-group-2", stableDescription));
-
-        List<ConsumerGroup> result = consumerGroupService.findExternalByWildcardName(namespace, "*");
-
-        assertEquals(2, result.size());
-        assertEquals(
-                "namespace-topic",
-                result.get(0).getStatus().getOffsets().getFirst().getTopic());
-        assertEquals(
-                "namespace-topic-2",
-                result.get(1).getStatus().getOffsets().getFirst().getTopic());
     }
 
     @Test
@@ -398,26 +265,14 @@ class ConsumerGroupServiceTest {
                         .build())
                 .build();
 
-        List<AccessControlEntry> topicOwnerAcls = List.of(AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
-                        .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
-                        .permission(AccessControlEntry.Permission.OWNER)
-                        .grantedTo("namespace")
-                        .resource("namespace-")
-                        .build())
-                .build());
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))
                 .thenReturn(consumerGroupAsyncExecutor);
-        when(consumerGroupAsyncExecutor.listConsumerGroupIds()).thenReturn(List.of("namespace-group1"));
-        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.GROUP))
-                .thenReturn(List.of());
-        when(aclService.findResourceOwnerGrantedToNamespace(namespace, AccessControlEntry.ResourceType.TOPIC))
-                .thenReturn(topicOwnerAcls);
-        when(consumerGroupAsyncExecutor.getCommittedOffsets("namespace-group1"))
+        when(consumerGroupAsyncExecutor.listConsumerGroupIds()).thenReturn(List.of("abc.group1"));
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "abc.group1"))
+                .thenReturn(false);
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("abc.group1"))
                 .thenThrow(new ExecutionException(new RuntimeException("boom")));
 
         List<ConsumerGroup> result = consumerGroupService.findExternalByWildcardName(namespace, "*");
@@ -622,7 +477,6 @@ class ConsumerGroupServiceTest {
         TopicPartition topicPartition2 = new TopicPartition("topic1", 1);
         TopicPartition topicPartition3 = new TopicPartition("topic2", 0);
 
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))
@@ -651,7 +505,6 @@ class ConsumerGroupServiceTest {
         TopicPartition topicPartition1 = new TopicPartition("topic1", 0);
         TopicPartition topicPartition2 = new TopicPartition("topic1", 1);
 
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))
@@ -692,7 +545,6 @@ class ConsumerGroupServiceTest {
         TopicPartition topicPartition2 = new TopicPartition("topic1", 1);
         List<TopicPartition> partitionsToReset = List.of(topicPartition1, topicPartition2);
 
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))
@@ -729,7 +581,6 @@ class ConsumerGroupServiceTest {
         ConsumerGroupDescription consumerGroupDescription =
                 new ConsumerGroupDescription(null, true, null, null, null, GroupState.STABLE, null, null, null, null);
 
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))
@@ -751,7 +602,6 @@ class ConsumerGroupServiceTest {
 
         String groupId = "testGroup";
 
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))
@@ -771,7 +621,6 @@ class ConsumerGroupServiceTest {
                 .build();
         String groupId = "testGroup";
 
-        ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor = mock(ConsumerGroupAsyncExecutor.class);
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
                         Qualifiers.byName(namespace.getMetadata().getCluster())))


### PR DESCRIPTION
# Context

This pull request adds the 2nd feature of the consumer group listing epic.

The first feature, which lists consumer groups owned by the namespace, was introduced in <https://github.com/michelin/ns4kafka/pull/775>.

This follow-up focuses on a different use case: listing external consumer groups that are consuming topics owned by the namespace.

# Proposed solution

Introduce a dedicated endpoint for external consumer groups instead of changing the existing owned consumer group endpoint.

This keeps feature 1 behavior unchanged while exposing a separate API for feature 2.

# Implementation

I added a new endpoint:

`GET /api/namespaces/{namespace}/consumer-groups/external`

The implementation now:

- keeps the existing `/consumer-groups` endpoint scoped to consumer groups owned by the namespace
- adds a separate service flow to list only external consumer groups
- filters out consumer groups already owned by the namespace
- keeps only consumer groups that have committed offsets on topics owned by the namespace
- includes committed offsets in the response so the consumed topic is visible in the payload

# Tests

I added and updated focused tests to cover:

- the new controller endpoint
- listing only external consumer groups consuming namespace-owned topics
- returning topic information in the response offsets for multiple consumer groups
- ignoring consumer groups when committed offsets cannot be read safely

# Remark

This change was kept intentionally separated from feature 1 so both endpoints remain explicit and easy to understand:

- `/consumer-groups` for namespace-owned consumer groups
- `/consumer-groups/external` for external consumer groups consuming namespace-owned topics
