### PR TITLE
Filter out non-consumer groups from consumer group listing

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/service/executor/ConsumerGroupAsyncExecutor.java
+++ b/src/main/java/com/michelin/ns4kafka/service/executor/ConsumerGroupAsyncExecutor.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.GroupListing;
 import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.TopicPartition;
 
 /** Consumer group executor. */
@@ -70,6 +71,8 @@ public class ConsumerGroupAsyncExecutor {
      */
     public List<String> listConsumerGroupIds() throws ExecutionException, InterruptedException {
         return getAdminClient().listGroups().all().get().stream()
+                .filter(groupListing -> groupListing.type().orElse(null) == GroupType.CONSUMER
+                        || "consumer".equals(groupListing.protocol()))
                 .map(GroupListing::groupId)
                 .toList();
     }

--- a/src/test/java/com/michelin/ns4kafka/service/executor/ConsumerGroupAsyncExecutorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/executor/ConsumerGroupAsyncExecutorTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.michelin.ns4kafka.service.executor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.GroupListing;
+import org.apache.kafka.clients.admin.ListGroupsResult;
+import org.apache.kafka.common.GroupState;
+import org.apache.kafka.common.GroupType;
+import org.apache.kafka.common.KafkaFuture;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.when;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.michelin.ns4kafka.property.ManagedClusterProperties;
+
+@ExtendWith(MockitoExtension.class)
+class ConsumerGroupAsyncExecutorTest {
+    @Mock
+    ManagedClusterProperties managedClusterProperties;
+
+    @Mock
+    Admin adminClient;
+
+    @Mock
+    ListGroupsResult listGroupsResult;
+
+    @InjectMocks
+    ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor;
+
+    @Test
+    void shouldListOnlyConsumerGroups() throws ExecutionException, InterruptedException {
+        GroupListing classicConsumerGroup = new GroupListing(
+                "classic-consumer-group", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE));
+        GroupListing newConsumerGroup = new GroupListing(
+                "new-consumer-group", Optional.of(GroupType.CONSUMER), "consumer", Optional.of(GroupState.STABLE));
+        GroupListing connectGroup = new GroupListing(
+                "connect-group", Optional.of(GroupType.CLASSIC), "connect", Optional.of(GroupState.STABLE));
+        GroupListing streamsGroup = new GroupListing(
+                "streams-group", Optional.of(GroupType.STREAMS), "stream", Optional.of(GroupState.STABLE));
+        GroupListing shareGroup = new GroupListing(
+                "share-group", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE));
+
+        when(managedClusterProperties.getAdminClient()).thenReturn(adminClient);
+        when(adminClient.listGroups()).thenReturn(listGroupsResult);
+        when(listGroupsResult.all())
+                .thenReturn(KafkaFuture.completedFuture(
+                        List.of(classicConsumerGroup, newConsumerGroup, connectGroup, streamsGroup, shareGroup)));
+
+        List<String> result = consumerGroupAsyncExecutor.listConsumerGroupIds();
+
+        assertEquals(2, result.size());
+        assertTrue(result.contains("classic-consumer-group"));
+        assertTrue(result.contains("new-consumer-group"));
+    }
+
+    @Test
+    void shouldFilterOutConnectGroups() throws ExecutionException, InterruptedException {
+        GroupListing connectGroup = new GroupListing(
+                "compose-connect-group", Optional.of(GroupType.CLASSIC), "connect", Optional.of(GroupState.STABLE));
+        GroupListing consumerGroup = new GroupListing(
+                "my-consumer-group", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE));
+
+        when(managedClusterProperties.getAdminClient()).thenReturn(adminClient);
+        when(adminClient.listGroups()).thenReturn(listGroupsResult);
+        when(listGroupsResult.all())
+                .thenReturn(KafkaFuture.completedFuture(List.of(connectGroup, consumerGroup)));
+
+        List<String> result = consumerGroupAsyncExecutor.listConsumerGroupIds();
+
+        assertEquals(1, result.size());
+        assertEquals("my-consumer-group", result.getFirst());
+    }
+
+    @Test
+    void shouldFilterOutGroupsWithEmptyType() throws ExecutionException, InterruptedException {
+        GroupListing emptyTypeGroup =
+                new GroupListing("empty-type-group", Optional.empty(), "", Optional.empty());
+        GroupListing classicGroup =
+                new GroupListing("classic-group", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE));
+
+        when(managedClusterProperties.getAdminClient()).thenReturn(adminClient);
+        when(adminClient.listGroups()).thenReturn(listGroupsResult);
+        when(listGroupsResult.all())
+                .thenReturn(KafkaFuture.completedFuture(List.of(emptyTypeGroup, classicGroup)));
+
+        List<String> result = consumerGroupAsyncExecutor.listConsumerGroupIds();
+
+        assertEquals(1, result.size());
+        assertEquals("classic-group", result.getFirst());
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoConsumerGroups() throws ExecutionException, InterruptedException {
+        GroupListing streamsGroup =
+                new GroupListing("streams-group", Optional.of(GroupType.STREAMS), "stream", Optional.of(GroupState.STABLE));
+
+        when(managedClusterProperties.getAdminClient()).thenReturn(adminClient);
+        when(adminClient.listGroups()).thenReturn(listGroupsResult);
+        when(listGroupsResult.all()).thenReturn(KafkaFuture.completedFuture(List.of(streamsGroup)));
+
+        List<String> result = consumerGroupAsyncExecutor.listConsumerGroupIds();
+
+        assertTrue(result.isEmpty());
+    }
+}

--- a/src/test/java/com/michelin/ns4kafka/service/executor/ConsumerGroupAsyncExecutorTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/executor/ConsumerGroupAsyncExecutorTest.java
@@ -18,26 +18,25 @@
  */
 package com.michelin.ns4kafka.service.executor;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import com.michelin.ns4kafka.property.ManagedClusterProperties;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.GroupListing;
 import org.apache.kafka.clients.admin.ListGroupsResult;
 import org.apache.kafka.common.GroupState;
 import org.apache.kafka.common.GroupType;
 import org.apache.kafka.common.KafkaFuture;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import com.michelin.ns4kafka.property.ManagedClusterProperties;
 
 @ExtendWith(MockitoExtension.class)
 class ConsumerGroupAsyncExecutorTest {
@@ -63,8 +62,8 @@ class ConsumerGroupAsyncExecutorTest {
                 "connect-group", Optional.of(GroupType.CLASSIC), "connect", Optional.of(GroupState.STABLE));
         GroupListing streamsGroup = new GroupListing(
                 "streams-group", Optional.of(GroupType.STREAMS), "stream", Optional.of(GroupState.STABLE));
-        GroupListing shareGroup = new GroupListing(
-                "share-group", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE));
+        GroupListing shareGroup =
+                new GroupListing("share-group", Optional.of(GroupType.SHARE), "share", Optional.of(GroupState.STABLE));
 
         when(managedClusterProperties.getAdminClient()).thenReturn(adminClient);
         when(adminClient.listGroups()).thenReturn(listGroupsResult);
@@ -88,8 +87,7 @@ class ConsumerGroupAsyncExecutorTest {
 
         when(managedClusterProperties.getAdminClient()).thenReturn(adminClient);
         when(adminClient.listGroups()).thenReturn(listGroupsResult);
-        when(listGroupsResult.all())
-                .thenReturn(KafkaFuture.completedFuture(List.of(connectGroup, consumerGroup)));
+        when(listGroupsResult.all()).thenReturn(KafkaFuture.completedFuture(List.of(connectGroup, consumerGroup)));
 
         List<String> result = consumerGroupAsyncExecutor.listConsumerGroupIds();
 
@@ -99,15 +97,13 @@ class ConsumerGroupAsyncExecutorTest {
 
     @Test
     void shouldFilterOutGroupsWithEmptyType() throws ExecutionException, InterruptedException {
-        GroupListing emptyTypeGroup =
-                new GroupListing("empty-type-group", Optional.empty(), "", Optional.empty());
-        GroupListing classicGroup =
-                new GroupListing("classic-group", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE));
+        GroupListing emptyTypeGroup = new GroupListing("empty-type-group", Optional.empty(), "", Optional.empty());
+        GroupListing classicGroup = new GroupListing(
+                "classic-group", Optional.of(GroupType.CLASSIC), "consumer", Optional.of(GroupState.STABLE));
 
         when(managedClusterProperties.getAdminClient()).thenReturn(adminClient);
         when(adminClient.listGroups()).thenReturn(listGroupsResult);
-        when(listGroupsResult.all())
-                .thenReturn(KafkaFuture.completedFuture(List.of(emptyTypeGroup, classicGroup)));
+        when(listGroupsResult.all()).thenReturn(KafkaFuture.completedFuture(List.of(emptyTypeGroup, classicGroup)));
 
         List<String> result = consumerGroupAsyncExecutor.listConsumerGroupIds();
 
@@ -117,8 +113,8 @@ class ConsumerGroupAsyncExecutorTest {
 
     @Test
     void shouldReturnEmptyListWhenNoConsumerGroups() throws ExecutionException, InterruptedException {
-        GroupListing streamsGroup =
-                new GroupListing("streams-group", Optional.of(GroupType.STREAMS), "stream", Optional.of(GroupState.STABLE));
+        GroupListing streamsGroup = new GroupListing(
+                "streams-group", Optional.of(GroupType.STREAMS), "stream", Optional.of(GroupState.STABLE));
 
         when(managedClusterProperties.getAdminClient()).thenReturn(adminClient);
         when(adminClient.listGroups()).thenReturn(listGroupsResult);


### PR DESCRIPTION
## Context

The consumer group listing endpoint (`GET /api/namespaces/{namespace}/consumer-groups`) returns HTTP 500 when
the Kafka cluster contains non-consumer groups (e.g., Kafka Connect groups) that match the namespace's GROUP ACLs.

The error occurs because `listConsumerGroupIds()` uses `Admin.listGroups()` which returns **all** group types
(consumer, connect, streams, share), and then `describeConsumerGroups()` is called on all of them. The Kafka
Admin API rejects non-consumer groups with:

GroupId kfe.connect-cluster is not a consumer group (connect).


Resolves https://github.com/michelin/ns4kafka/issues/802

## Proposed solution

Filter the group listing to only include actual consumer groups before passing them to `describeConsumerGroups()`.

The filtering uses two criteria from `GroupListing`:
- **`type() == CONSUMER`** - matches groups using the new consumer group protocol (KIP-848)
- **`protocol() == "consumer"`** - matches classic consumer groups

This excludes connect groups (protocol = **connect**, streams groups, share groups, and any other
non-consumer group type).

## Implementation

Updated `ConsumerGroupAsyncExecutor.listConsumerGroupIds()` to filter the results of `Admin.listGroups()`
by checking the group type and protocol. Only groups that are confirmed consumer groups are returned.

Note: Filtering by `GroupType` alone is not sufficient because both consumer groups and connect groups
share the `CLASSIC` group type. The `protocol()` field is the key differentiator (`"consumer"` vs `"connect"`).

## Tests

Added `ConsumerGroupAsyncExecutorTest` with 4 test cases:
- Filters out connect, streams, and share groups while keeping classic and new consumer groups
- Specifically verifies connect groups (same `CLASSIC` type as consumer groups) are excluded
- Filters out groups with empty type
- Returns empty list when no consumer groups exist

Existing `ConsumerGroupServiceTest` tests continue to pass unchanged.

## Remark

The change scoped to the executor layer where the Kafka Admin API interaction happens.
No changes to the service or controller layers were needed.