### PR TITLE
Add the ability to stop connectors 

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controller/connect/ConnectorController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/connect/ConnectorController.java
@@ -305,6 +305,7 @@ public class ConnectorController extends NamespacedResourceController {
             case RESTART -> response = connectorService.restart(ns, optionalConnector.get());
             case PAUSE -> response = connectorService.pause(ns, optionalConnector.get());
             case RESUME -> response = connectorService.resume(ns, optionalConnector.get());
+            case STOP -> response = connectorService.stop(ns, optionalConnector.get());
             default -> {
                 return Mono.error(new IllegalStateException(
                         "Unspecified action " + state.getSpec().getAction()));

--- a/src/main/java/com/michelin/ns4kafka/model/connect/ChangeConnectorState.java
+++ b/src/main/java/com/michelin/ns4kafka/model/connect/ChangeConnectorState.java
@@ -59,7 +59,8 @@ public class ChangeConnectorState extends Resource {
     public enum ConnectorAction {
         PAUSE,
         RESUME,
-        RESTART;
+        RESTART,
+        STOP;
 
         /**
          * Build connector action from string.

--- a/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
@@ -384,4 +384,28 @@ public class ConnectorService {
                     return HttpResponse.accepted();
                 });
     }
+
+        /**
+         * Stop a given connector.
+         *
+         * @param namespace The namespace
+         * @param connector The connector
+         * @return An HTTP response
+         */
+        public Mono<HttpResponse<Void>> stop(Namespace namespace, Connector connector) {
+                return kafkaConnectClient
+                                .stop(
+                                                namespace.getMetadata().getCluster(),
+                                                connector.getSpec().getConnectCluster(),
+                                                connector.getMetadata().getName())
+                                .map(_ -> {
+                                        log.info(
+                                                        "Success stopping Connector [{}] on Namespace [{}] Connect [{}]",
+                                                        connector.getMetadata().getName(),
+                                                        namespace.getMetadata().getName(),
+                                                        connector.getSpec().getConnectCluster());
+
+                                        return HttpResponse.accepted();
+                                });
+        }
 }

--- a/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
@@ -385,27 +385,27 @@ public class ConnectorService {
                 });
     }
 
-        /**
-         * Stop a given connector.
-         *
-         * @param namespace The namespace
-         * @param connector The connector
-         * @return An HTTP response
-         */
-        public Mono<HttpResponse<Void>> stop(Namespace namespace, Connector connector) {
-                return kafkaConnectClient
-                                .stop(
-                                                namespace.getMetadata().getCluster(),
-                                                connector.getSpec().getConnectCluster(),
-                                                connector.getMetadata().getName())
-                                .map(_ -> {
-                                        log.info(
-                                                        "Success stopping Connector [{}] on Namespace [{}] Connect [{}]",
-                                                        connector.getMetadata().getName(),
-                                                        namespace.getMetadata().getName(),
-                                                        connector.getSpec().getConnectCluster());
+    /**
+     * Stop a given connector.
+     *
+     * @param namespace The namespace
+     * @param connector The connector
+     * @return An HTTP response
+     */
+    public Mono<HttpResponse<Void>> stop(Namespace namespace, Connector connector) {
+        return kafkaConnectClient
+                .stop(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName())
+                .map(_ -> {
+                    log.info(
+                            "Success stopping Connector [{}] on Namespace [{}] Connect [{}]",
+                            connector.getMetadata().getName(),
+                            namespace.getMetadata().getName(),
+                            connector.getSpec().getConnectCluster());
 
-                                        return HttpResponse.accepted();
-                                });
-        }
+                    return HttpResponse.accepted();
+                });
+    }
 }

--- a/src/main/java/com/michelin/ns4kafka/service/client/connect/KafkaConnectClient.java
+++ b/src/main/java/com/michelin/ns4kafka/service/client/connect/KafkaConnectClient.java
@@ -334,6 +334,31 @@ public class KafkaConnectClient {
     }
 
     /**
+     * Stop a connector.
+     *
+     * @param kafkaCluster The Kafka cluster
+     * @param connectCluster The Kafka Connect
+     * @param connector The connector
+     * @return The stop response
+     */
+    @Retryable(
+            delay = "${ns4kafka.retry.delay}",
+            attempts = "${ns4kafka.retry.attempt}",
+            multiplier = "${ns4kafka.retry.multiplier}",
+            includes = ReadTimeoutException.class)
+    public Mono<HttpResponse<Void>> stop(String kafkaCluster, String connectCluster, String connector) {
+        KafkaConnectHttpConfig config = getKafkaConnectConfig(kafkaCluster, connectCluster);
+        String encodedConnector = URLEncoder.encode(connector, StandardCharsets.UTF_8);
+
+        HttpRequest<?> request = HttpRequest.PUT(
+                        URI.create(StringUtils.prependUri(config.getUrl(), CONNECTORS + encodedConnector + "/stop")),
+                        null)
+                .basicAuth(config.getUsername(), config.getPassword());
+
+        return Mono.from(httpClient.exchange(request, Void.class));
+    }
+
+    /**
      * Get the Kafka Connect configuration.
      *
      * @param kafkaCluster The Kafka cluster

--- a/src/test/java/com/michelin/ns4kafka/integration/ConnectorIntegrationTest.java
+++ b/src/test/java/com/michelin/ns4kafka/integration/ConnectorIntegrationTest.java
@@ -673,9 +673,7 @@ class ConnectorIntegrationTest extends KafkaConnectIntegrationTest {
         assertEquals("RUNNING", actual.connector().getState());
 
         ChangeConnectorState stopState = ChangeConnectorState.builder()
-                .metadata(Resource.Metadata.builder()
-                        .name("ns1-connector-stop")
-                        .build())
+                .metadata(Resource.Metadata.builder().name("ns1-connector-stop").build())
                 .spec(ChangeConnectorState.ChangeConnectorStateSpec.builder()
                         .action(ChangeConnectorState.ConnectorAction.STOP)
                         .build())
@@ -684,8 +682,7 @@ class ConnectorIntegrationTest extends KafkaConnectIntegrationTest {
         HttpResponse<ChangeConnectorState> stopResponse = ns4KafkaClient
                 .toBlocking()
                 .exchange(HttpRequest.create(
-                                HttpMethod.POST,
-                                "/api/namespaces/ns1/connectors/ns1-connector-stop/change-state")
+                                HttpMethod.POST, "/api/namespaces/ns1/connectors/ns1-connector-stop/change-state")
                         .bearerAuth(token)
                         .body(stopState));
 

--- a/src/test/java/com/michelin/ns4kafka/integration/ConnectorIntegrationTest.java
+++ b/src/test/java/com/michelin/ns4kafka/integration/ConnectorIntegrationTest.java
@@ -622,6 +622,85 @@ class ConnectorIntegrationTest extends KafkaConnectIntegrationTest {
     }
 
     @Test
+    void shouldStopConnector() throws InterruptedException {
+        Topic topic = Topic.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns1-topic5")
+                        .namespace("ns1")
+                        .build())
+                .spec(Topic.TopicSpec.builder()
+                        .partitions(3)
+                        .replicationFactor(1)
+                        .configs(
+                                Map.of("cleanup.policy", "delete", "min.insync.replicas", "1", "retention.ms", "60000"))
+                        .build())
+                .build();
+
+        Connector connector = Connector.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns1-connector-stop")
+                        .namespace("ns1")
+                        .build())
+                .spec(Connector.ConnectorSpec.builder()
+                        .connectCluster("test-connect")
+                        .config(Map.of(
+                                "connector.class", "org.apache.kafka.connect.file.FileStreamSinkConnector",
+                                "tasks.max", "1",
+                                "topics", "ns1-topic5"))
+                        .build())
+                .build();
+
+        ns4KafkaClient
+                .toBlocking()
+                .exchange(HttpRequest.create(HttpMethod.POST, "/api/namespaces/ns1/topics")
+                        .bearerAuth(token)
+                        .body(topic));
+
+        topicAsyncExecutorList.forEach(TopicAsyncExecutor::run);
+        ns4KafkaClient
+                .toBlocking()
+                .exchange(HttpRequest.create(HttpMethod.POST, "/api/namespaces/ns1/connectors")
+                        .bearerAuth(token)
+                        .body(connector));
+
+        forceConnectorSynchronization();
+        waitForConnectorToBeInState("ns1-connector-stop", "RUNNING");
+
+        ConnectorStateInfo actual = connectClient
+                .toBlocking()
+                .retrieve(HttpRequest.GET("/connectors/ns1-connector-stop/status"), ConnectorStateInfo.class);
+
+        assertEquals("RUNNING", actual.connector().getState());
+
+        ChangeConnectorState stopState = ChangeConnectorState.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns1-connector-stop")
+                        .build())
+                .spec(ChangeConnectorState.ChangeConnectorStateSpec.builder()
+                        .action(ChangeConnectorState.ConnectorAction.STOP)
+                        .build())
+                .build();
+
+        HttpResponse<ChangeConnectorState> stopResponse = ns4KafkaClient
+                .toBlocking()
+                .exchange(HttpRequest.create(
+                                HttpMethod.POST,
+                                "/api/namespaces/ns1/connectors/ns1-connector-stop/change-state")
+                        .bearerAuth(token)
+                        .body(stopState));
+
+        assertEquals(HttpStatus.OK, stopResponse.status());
+
+        waitForConnectorToBeInState("ns1-connector-stop", "STOPPED");
+
+        actual = connectClient
+                .toBlocking()
+                .retrieve(HttpRequest.GET("/connectors/ns1-connector-stop/status"), ConnectorStateInfo.class);
+
+        assertEquals("STOPPED", actual.connector().getState());
+    }
+
+    @Test
     void shouldNotCreateConnectorWhenStrictRegexPatternDoesNotMatchName() {
         Namespace namespace = Namespace.builder()
                 .metadata(Resource.Metadata.builder()

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
@@ -1407,4 +1407,37 @@ class ConnectorServiceTest {
                         connector.getMetadata().getName(),
                         2);
     }
+
+    @Test
+    void shouldStopConnector() {
+        Namespace namespace = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("namespace")
+                        .cluster("local")
+                        .build())
+                .build();
+
+        Connector connector = Connector.builder()
+                .metadata(Resource.Metadata.builder().name("ns-connect1").build())
+                .spec(Connector.ConnectorSpec.builder()
+                        .connectCluster("local-name")
+                        .build())
+                .build();
+
+        when(kafkaConnectClient.stop(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName()))
+                .thenReturn(Mono.just(HttpResponse.noContent()));
+
+        StepVerifier.create(connectorService.stop(namespace, connector))
+                .consumeNextWith(response -> assertEquals(HttpStatus.ACCEPTED, response.getStatus()))
+                .verifyComplete();
+
+        verify(kafkaConnectClient)
+                .stop(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName());
+    }
 }


### PR DESCRIPTION
## Context

This change adds support for stopping a Kafka Connect connector from Ns4Kafka.

Until now, the connector state change flow supported `RESTART`, `PAUSE`, and `RESUME`, but not `STOP`. As a result, users could not stop a connector through the existing `change-state` API even though stop is a valid Kafka Connect operation.

The goal of this PR is to expose connector stop through the existing connector state change workflow.

## Proposed solution

I extended the existing `ChangeConnectorState` flow to support a new `STOP` action.

The objective was to keep the implementation aligned with the current connector action model, so stop uses the same request shape and dispatching logic as the other connector state transitions.

## Implementation

I added `STOP` to the `ChangeConnectorState.ConnectorAction` enum so it can be accepted through the existing `change-state` request body.

I then wired the `STOP` action in the connector controller so `POST /api/namespaces/{namespace}/connectors/{connector}/change-state` dispatches to the connector service when `spec.action` is set to `STOP`.

On the service side, I added the handling needed to:

- call Kafka Connect stop for the targeted connector
- return an accepted response consistent with the other connector state operations
- keep the implementation aligned with the current service and client structure

## Tests

I added service-level coverage for the new stop flow in `ConnectorServiceTest`.

I also added an integration test in `ConnectorIntegrationTest` to verify the end-to-end `change-state` flow with `STOP`, including the transition from `RUNNING` to `STOPPED` on Kafka Connect.

## Remark

`STOP` is supported through the shared `change-state` API, which avoids adding a duplicated controller entrypoint for the same underlying behavior.