### PR TITLE
Support listing all Kafka Connects with decrypted fields

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/service/ConnectClusterService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConnectClusterService.java
@@ -105,8 +105,8 @@ public class ConnectClusterService {
      * @return A list of Connect clusters
      */
     public Flux<ConnectCluster> findAll(boolean all, boolean status) {
-        Flux<ConnectCluster> selfHostedConnectClusters = Flux.defer(() -> Flux.fromIterable(
-                        connectClusterRepository.findAll()))
+        Flux<ConnectCluster> selfHostedConnectClusters = Flux.defer(
+                        () -> Flux.fromIterable(connectClusterRepository.findAll()))
                 .map(this::buildConnectClusterWithDecryptedSecrets);
 
         Flux<ConnectCluster> managedConnectClusters = all
@@ -446,33 +446,33 @@ public class ConnectClusterService {
                 .build();
     }
 
-        private ConnectCluster buildConnectClusterWithDecryptedSecrets(ConnectCluster connectCluster) {
-                return ConnectCluster.builder()
-                                .metadata(connectCluster.getMetadata())
-                                .spec(ConnectCluster.ConnectClusterSpec.builder()
-                                                .url(connectCluster.getSpec().getUrl())
-                                                .username(connectCluster.getSpec().getUsername())
-                                                .password(decryptSecret(connectCluster.getSpec().getPassword()))
-                                                .status(connectCluster.getSpec().getStatus())
-                                                .statusMessage(connectCluster.getSpec().getStatusMessage())
-                                                .aes256Key(decryptSecret(connectCluster.getSpec().getAes256Key()))
-                                                .aes256Salt(decryptSecret(connectCluster.getSpec().getAes256Salt()))
-                                                .aes256Format(connectCluster.getSpec().getAes256Format())
-                                                .build())
-                                .build();
+    private ConnectCluster buildConnectClusterWithDecryptedSecrets(ConnectCluster connectCluster) {
+        return ConnectCluster.builder()
+                .metadata(connectCluster.getMetadata())
+                .spec(ConnectCluster.ConnectClusterSpec.builder()
+                        .url(connectCluster.getSpec().getUrl())
+                        .username(connectCluster.getSpec().getUsername())
+                        .password(decryptSecret(connectCluster.getSpec().getPassword()))
+                        .status(connectCluster.getSpec().getStatus())
+                        .statusMessage(connectCluster.getSpec().getStatusMessage())
+                        .aes256Key(decryptSecret(connectCluster.getSpec().getAes256Key()))
+                        .aes256Salt(decryptSecret(connectCluster.getSpec().getAes256Salt()))
+                        .aes256Format(connectCluster.getSpec().getAes256Format())
+                        .build())
+                .build();
+    }
+
+    private String decryptSecret(String encryptedText) {
+        if (!StringUtils.hasText(encryptedText)) {
+            return encryptedText;
         }
 
-        private String decryptSecret(String encryptedText) {
-                if (!StringUtils.hasText(encryptedText)) {
-                        return encryptedText;
-                }
-
-                if (ns4KafkaProperties.getSecurity() == null
-                                || !StringUtils.hasText(ns4KafkaProperties.getSecurity().getAes256EncryptionKey())) {
-                        return encryptedText;
-                }
-
-                return EncryptionUtils.decryptAes256Gcm(
-                                encryptedText, ns4KafkaProperties.getSecurity().getAes256EncryptionKey());
+        if (ns4KafkaProperties.getSecurity() == null
+                || !StringUtils.hasText(ns4KafkaProperties.getSecurity().getAes256EncryptionKey())) {
+            return encryptedText;
         }
+
+        return EncryptionUtils.decryptAes256Gcm(
+                encryptedText, ns4KafkaProperties.getSecurity().getAes256EncryptionKey());
+    }
 }

--- a/src/main/java/com/michelin/ns4kafka/service/ConnectClusterService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConnectClusterService.java
@@ -105,8 +105,9 @@ public class ConnectClusterService {
      * @return A list of Connect clusters
      */
     public Flux<ConnectCluster> findAll(boolean all, boolean status) {
-        Flux<ConnectCluster> selfHostedConnectClusters =
-                Flux.defer(() -> Flux.fromIterable(connectClusterRepository.findAll()));
+        Flux<ConnectCluster> selfHostedConnectClusters = Flux.defer(() -> Flux.fromIterable(
+                        connectClusterRepository.findAll()))
+                .map(this::buildConnectClusterWithDecryptedSecrets);
 
         Flux<ConnectCluster> managedConnectClusters = all
                 ? Flux.fromIterable(managedClusterProperties)
@@ -422,15 +423,9 @@ public class ConnectClusterService {
                 ConnectCluster.ConnectClusterSpec.builder()
                         .url(connectCluster.getSpec().getUrl())
                         .username(connectCluster.getSpec().getUsername())
-                        .password(EncryptionUtils.decryptAes256Gcm(
-                                connectCluster.getSpec().getPassword(),
-                                ns4KafkaProperties.getSecurity().getAes256EncryptionKey()))
-                        .aes256Key(EncryptionUtils.decryptAes256Gcm(
-                                connectCluster.getSpec().getAes256Key(),
-                                ns4KafkaProperties.getSecurity().getAes256EncryptionKey()))
-                        .aes256Salt(EncryptionUtils.decryptAes256Gcm(
-                                connectCluster.getSpec().getAes256Salt(),
-                                ns4KafkaProperties.getSecurity().getAes256EncryptionKey()))
+                        .password(decryptSecret(connectCluster.getSpec().getPassword()))
+                        .aes256Key(decryptSecret(connectCluster.getSpec().getAes256Key()))
+                        .aes256Salt(decryptSecret(connectCluster.getSpec().getAes256Salt()))
                         .aes256Format(connectCluster.getSpec().getAes256Format())
                         .status(
                                 healthyConnectClusters
@@ -450,4 +445,34 @@ public class ConnectClusterService {
                 .spec(builder.build())
                 .build();
     }
+
+        private ConnectCluster buildConnectClusterWithDecryptedSecrets(ConnectCluster connectCluster) {
+                return ConnectCluster.builder()
+                                .metadata(connectCluster.getMetadata())
+                                .spec(ConnectCluster.ConnectClusterSpec.builder()
+                                                .url(connectCluster.getSpec().getUrl())
+                                                .username(connectCluster.getSpec().getUsername())
+                                                .password(decryptSecret(connectCluster.getSpec().getPassword()))
+                                                .status(connectCluster.getSpec().getStatus())
+                                                .statusMessage(connectCluster.getSpec().getStatusMessage())
+                                                .aes256Key(decryptSecret(connectCluster.getSpec().getAes256Key()))
+                                                .aes256Salt(decryptSecret(connectCluster.getSpec().getAes256Salt()))
+                                                .aes256Format(connectCluster.getSpec().getAes256Format())
+                                                .build())
+                                .build();
+        }
+
+        private String decryptSecret(String encryptedText) {
+                if (!StringUtils.hasText(encryptedText)) {
+                        return encryptedText;
+                }
+
+                if (ns4KafkaProperties.getSecurity() == null
+                                || !StringUtils.hasText(ns4KafkaProperties.getSecurity().getAes256EncryptionKey())) {
+                        return encryptedText;
+                }
+
+                return EncryptionUtils.decryptAes256Gcm(
+                                encryptedText, ns4KafkaProperties.getSecurity().getAes256EncryptionKey());
+        }
 }

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectClusterServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectClusterServiceTest.java
@@ -106,6 +106,37 @@ class ConnectClusterServiceTest {
     }
 
     @Test
+    void shouldFindAllConnectClustersWithDecryptedInformation() {
+        String encryptKey = "changeitchangeitchangeitchangeit";
+        ConnectCluster connectCluster = ConnectCluster.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("connect-cluster")
+                        .cluster("local")
+                        .build())
+                .spec(ConnectCluster.ConnectClusterSpec.builder()
+                        .url("https://after")
+                        .username("user")
+                        .password(EncryptionUtils.encryptAes256Gcm("password", encryptKey))
+                        .aes256Key(EncryptionUtils.encryptAes256Gcm("aes256Key", encryptKey))
+                        .aes256Salt(EncryptionUtils.encryptAes256Gcm("aes256Salt", encryptKey))
+                        .build())
+                .build();
+
+        when(connectClusterRepository.findAll()).thenReturn(List.of(connectCluster));
+        when(ns4KafkaProperties.getSecurity()).thenReturn(buildSecurityProperties(encryptKey));
+
+        StepVerifier.create(connectClusterService.findAll(false, false))
+                .consumeNextWith(result -> {
+                    assertEquals("connect-cluster", result.getMetadata().getName());
+                    assertEquals("user", result.getSpec().getUsername());
+                    assertEquals("password", result.getSpec().getPassword());
+                    assertEquals("aes256Key", result.getSpec().getAes256Key());
+                    assertEquals("aes256Salt", result.getSpec().getAes256Salt());
+                })
+                .verifyComplete();
+    }
+
+    @Test
     void shouldFindAllConnectClustersIncludingThoseDeclaredInNs4KafkaConfig() {
         ConnectCluster connectCluster = ConnectCluster.builder()
                 .metadata(Resource.Metadata.builder().name("connect-cluster").build())
@@ -309,7 +340,6 @@ class ConnectClusterServiceTest {
                                 .build())
                         .build());
 
-        when(ns4KafkaProperties.getSecurity()).thenReturn(buildSecurityProperties("aes256Key"));
         when(connectClusterRepository.findAllForCluster("local")).thenReturn(List.of(cc1, cc2));
         when(aclService.findAllGrantedToNamespace(namespace)).thenReturn(acls);
         when(aclService.isResourceCoveredByAcls(acls, "abc.cc")).thenReturn(true);
@@ -396,7 +426,6 @@ class ConnectClusterServiceTest {
                                 .build())
                         .build());
 
-        when(ns4KafkaProperties.getSecurity()).thenReturn(buildSecurityProperties("aes256Key"));
         when(connectClusterRepository.findAllForCluster("local")).thenReturn(List.of(cc1, cc2, cc3, cc4, cc5));
         when(aclService.findAllGrantedToNamespace(namespace)).thenReturn(acls);
         when(aclService.isResourceCoveredByAcls(any(), eq("prefix.cc1"))).thenReturn(true);
@@ -544,7 +573,6 @@ class ConnectClusterServiceTest {
                                 .build())
                         .build()));
 
-        when(ns4KafkaProperties.getSecurity()).thenReturn(buildSecurityProperties("aes256Key"));
         when(aclService.isResourceCoveredByAcls(any(), eq("prefix.connect-cluster")))
                 .thenReturn(true);
 
@@ -591,7 +619,6 @@ class ConnectClusterServiceTest {
                                 .build())
                         .build()));
 
-        when(ns4KafkaProperties.getSecurity()).thenReturn(buildSecurityProperties("aes256Key"));
         when(aclService.isResourceCoveredByAcls(any(), eq("prefix.connect-cluster")))
                 .thenReturn(true);
 


### PR DESCRIPTION
## Context

The global Kafka Connect cluster listing endpoint was returning encrypted values for sensitive fields such as `password`, `aes256Key`, and `aes256Salt`, while the namespaced owner listing was already returning those fields decrypted.

This led to inconsistent behavior between:

- `GET /api/connect-clusters`
- `GET /api/namespaces/{namespace}/connect-clusters`

The goal of this change is to make the global listing consistent with the existing namespaced behavior so applications consuming these data can directly use the returned values without additional handling.

## Proposed solution

Decrypt self-hosted Kafka Connect cluster secrets when serving the global listing endpoint.

The expected behavior after this change is:

- namespaced listing continues to return decrypted values
- global listing now also returns decrypted values for self-hosted Connect clusters
- managed Connect clusters declared from configuration keep their existing behavior

## Implementation

I updated `ConnectClusterService.findAll(boolean all, boolean status)` so self-hosted Connect clusters loaded from the repository are mapped through a decryption step before being returned.

To keep the change small and consistent with the existing service logic, I introduced a dedicated helper to build a Connect cluster with decrypted secrets for the global list path, and a shared `decryptSecret(...)` helper to centralize the AES decryption logic.

I also reused the same decryption helper in the existing namespaced decryption path to avoid duplicating the secret decryption calls.

In practice, this means:

- secrets are still encrypted at write time before persistence
- secrets are now decrypted when returned by `GET /api/connect-clusters`
- status handling remains unchanged

## Tests

I added unit coverage in `ConnectClusterServiceTest` to verify that the global listing now returns decrypted values for:

- `password`
- `aes256Key`
- `aes256Salt`

I also kept the existing service behavior around status and managed Connect clusters covered by the surrounding test suite.

## Remark

This change does not alter the create flow or the storage model: sensitive fields remain encrypted at rest and are only decrypted when returned by the global listing API.