### PR TITLE
Add functionality to support partial and altered connector offsets

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controller/connect/ConnectorController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/connect/ConnectorController.java
@@ -43,7 +43,6 @@ import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
-import io.micronaut.http.annotation.Patch;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.scheduling.TaskExecutors;
@@ -402,7 +401,7 @@ public class ConnectorController extends NamespacedResourceController {
      * @param offsetsRequest The offsets payload
      * @return The connector offsets reset response
      */
-    @Patch("/{connector}/offsets")
+    @Post("/{connector}/offsets")
     public Mono<ConnectorResetOffsetsResponse> alterOffsets(
             String namespace, String connector, @Body ConnectorOffsets offsetsRequest) {
         Namespace ns = getNamespace(namespace);

--- a/src/main/java/com/michelin/ns4kafka/controller/connect/ConnectorController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/connect/ConnectorController.java
@@ -34,6 +34,7 @@ import com.michelin.ns4kafka.model.connect.ConnectorResetOffsetsResponse;
 import com.michelin.ns4kafka.service.ConnectorService;
 import com.michelin.ns4kafka.service.NamespaceService;
 import com.michelin.ns4kafka.service.ResourceQuotaService;
+import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsets;
 import com.michelin.ns4kafka.util.enumation.ApplyStatus;
 import com.michelin.ns4kafka.util.exception.ResourceValidationException;
 import io.micronaut.context.event.ApplicationEventPublisher;
@@ -42,6 +43,7 @@ import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Patch;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.scheduling.TaskExecutors;
@@ -384,6 +386,41 @@ public class ConnectorController extends NamespacedResourceController {
 
         return connectorService
                 .resetOffsets(ns, connectorToReset)
+                .map(_ -> ConnectorResetOffsetsResponse.builder()
+                        .metadata(connectorToReset.getMetadata())
+                        .status(ChangeConnectorState.ChangeConnectorStateStatus.builder()
+                                .code(ConnectorOperation.RESET)
+                                .build())
+                        .build());
+    }
+
+    /**
+     * Alter or partially reset the offsets of a connector.
+     *
+     * @param namespace The namespace
+     * @param connector The connector to alter offsets for
+     * @param offsetsRequest The offsets payload
+     * @return The connector offsets reset response
+     */
+    @Patch("/{connector}/offsets")
+    public Mono<ConnectorResetOffsetsResponse> alterOffsets(
+            String namespace, String connector, @Body ConnectorOffsets offsetsRequest) {
+        Namespace ns = getNamespace(namespace);
+
+        if (!connectorService.isNamespaceOwnerOfConnect(ns, connector)) {
+            return Mono.error(new ResourceValidationException(CONNECTOR, connector, invalidOwner(connector)));
+        }
+
+        Optional<Connector> optionalConnector = connectorService.findByName(ns, connector);
+
+        if (optionalConnector.isEmpty()) {
+            return Mono.empty();
+        }
+
+        Connector connectorToReset = optionalConnector.get();
+
+        return connectorService
+                .alterOffsets(ns, connectorToReset, offsetsRequest)
                 .map(_ -> ConnectorResetOffsetsResponse.builder()
                         .metadata(connectorToReset.getMetadata())
                         .status(ChangeConnectorState.ChangeConnectorStateStatus.builder()

--- a/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
@@ -30,6 +30,7 @@ import com.michelin.ns4kafka.model.connect.Connector;
 import com.michelin.ns4kafka.model.connect.ConnectorOffsetResponse;
 import com.michelin.ns4kafka.repository.ConnectorRepository;
 import com.michelin.ns4kafka.service.client.connect.KafkaConnectClient;
+import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsets;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsetsResponse;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorSpecs;
 import com.michelin.ns4kafka.util.FormatErrorUtils;
@@ -407,5 +408,32 @@ public class ConnectorService {
                 namespace.getMetadata().getCluster(),
                 connector.getSpec().getConnectCluster(),
                 connector.getMetadata().getName());
+    }
+
+    /**
+     * Alter offsets for a given connector.
+     *
+     * @param namespace The namespace
+     * @param connector The connector
+     * @param offsetsRequest The offsets payload
+     * @return An HTTP response
+     */
+    public Mono<HttpResponse<ConnectorOffsetsResponse>> alterOffsets(
+            Namespace namespace, Connector connector, ConnectorOffsets offsetsRequest) {
+        return kafkaConnectClient
+                .alterOffsets(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName(),
+                        offsetsRequest)
+                .map(response -> {
+                    log.info(
+                            "Success altering offsets for Connector [{}] on Namespace [{}] Connect [{}]",
+                            connector.getMetadata().getName(),
+                            namespace.getMetadata().getName(),
+                            connector.getSpec().getConnectCluster());
+
+                    return HttpResponse.status(response.getStatus()).body(response.body());
+                });
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/service/client/connect/KafkaConnectClient.java
+++ b/src/main/java/com/michelin/ns4kafka/service/client/connect/KafkaConnectClient.java
@@ -61,6 +61,7 @@ import reactor.core.publisher.Mono;
 @Singleton
 public class KafkaConnectClient {
     private static final String CONNECTORS = "/connectors/";
+    private static final String OFFSETS = "/offsets";
 
     private final ConnectClusterRepository connectClusterRepository;
     private final HttpClient httpClient;
@@ -264,7 +265,7 @@ public class KafkaConnectClient {
         String encodedConnector = URLEncoder.encode(connector, StandardCharsets.UTF_8);
 
         HttpRequest<?> request = HttpRequest.GET(
-                        URI.create(StringUtils.prependUri(config.getUrl(), CONNECTORS + encodedConnector + "/offsets")))
+                        URI.create(StringUtils.prependUri(config.getUrl(), CONNECTORS + encodedConnector + OFFSETS)))
                 .basicAuth(config.getUsername(), config.getPassword());
 
         return Mono.from(httpClient.retrieve(request, ConnectorOffsets.class))
@@ -394,7 +395,7 @@ public class KafkaConnectClient {
         String encodedConnector = URLEncoder.encode(connector, StandardCharsets.UTF_8);
 
         HttpRequest<?> request = HttpRequest.DELETE(
-                        URI.create(StringUtils.prependUri(config.getUrl(), CONNECTORS + encodedConnector + "/offsets")))
+                        URI.create(StringUtils.prependUri(config.getUrl(), CONNECTORS + encodedConnector + OFFSETS)))
                 .basicAuth(config.getUsername(), config.getPassword());
 
         return Mono.from(httpClient.exchange(request, ConnectorOffsetsResponse.class));
@@ -421,7 +422,7 @@ public class KafkaConnectClient {
 
         HttpRequest<?> request = HttpRequest.create(
                         HttpMethod.PATCH,
-                        StringUtils.prependUri(config.getUrl(), CONNECTORS + encodedConnector + "/offsets"))
+                        StringUtils.prependUri(config.getUrl(), CONNECTORS + encodedConnector + OFFSETS))
                 .body(offsetsRequest)
                 .basicAuth(config.getUsername(), config.getPassword());
 

--- a/src/main/java/com/michelin/ns4kafka/service/client/connect/KafkaConnectClient.java
+++ b/src/main/java/com/michelin/ns4kafka/service/client/connect/KafkaConnectClient.java
@@ -35,6 +35,7 @@ import com.michelin.ns4kafka.util.EncryptionUtils;
 import com.michelin.ns4kafka.util.exception.ResourceValidationException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -394,6 +395,34 @@ public class KafkaConnectClient {
 
         HttpRequest<?> request = HttpRequest.DELETE(
                         URI.create(StringUtils.prependUri(config.getUrl(), CONNECTORS + encodedConnector + "/offsets")))
+                .basicAuth(config.getUsername(), config.getPassword());
+
+        return Mono.from(httpClient.exchange(request, ConnectorOffsetsResponse.class));
+    }
+
+    /**
+     * Alter offsets for a connector.
+     *
+     * @param kafkaCluster The Kafka cluster
+     * @param connectCluster The Kafka Connect
+     * @param connector The connector
+     * @param offsetsRequest The offsets payload
+     * @return The alteration response
+     */
+    @Retryable(
+            delay = "${ns4kafka.retry.delay}",
+            attempts = "${ns4kafka.retry.attempt}",
+            multiplier = "${ns4kafka.retry.multiplier}",
+            includes = ReadTimeoutException.class)
+    public Mono<HttpResponse<ConnectorOffsetsResponse>> alterOffsets(
+            String kafkaCluster, String connectCluster, String connector, ConnectorOffsets offsetsRequest) {
+        KafkaConnectHttpConfig config = getKafkaConnectConfig(kafkaCluster, connectCluster);
+        String encodedConnector = URLEncoder.encode(connector, StandardCharsets.UTF_8);
+
+        HttpRequest<?> request = HttpRequest.create(
+                        HttpMethod.PATCH,
+                        StringUtils.prependUri(config.getUrl(), CONNECTORS + encodedConnector + "/offsets"))
+                .body(offsetsRequest)
                 .basicAuth(config.getUsername(), config.getPassword());
 
         return Mono.from(httpClient.exchange(request, ConnectorOffsetsResponse.class));

--- a/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
@@ -1270,8 +1270,8 @@ class ConnectorControllerTest {
                 .verifyComplete();
     }
 
-        @Test
-        void shouldNotResetConnectorOffsetsWhenError() {
+    @Test
+    void shouldNotResetConnectorOffsetsWhenError() {
         Namespace ns = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
                         .name("test")
@@ -1311,8 +1311,8 @@ class ConnectorControllerTest {
                 .metadata(Resource.Metadata.builder().name("connect1").build())
                 .build();
 
-        ConnectorOffsets offsetsRequest = new ConnectorOffsets(List.of(new ConnectorOffsets.ConnectorOffset(
-                Map.of("kafka_topic", "topic1", "kafka_partition", 0), null)));
+        ConnectorOffsets offsetsRequest = new ConnectorOffsets(List.of(
+                new ConnectorOffsets.ConnectorOffset(Map.of("kafka_topic", "topic1", "kafka_partition", 0), null)));
 
         when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
         when(connectorService.isNamespaceOwnerOfConnect(ns, "connect1")).thenReturn(true);
@@ -1322,7 +1322,8 @@ class ConnectorControllerTest {
 
         StepVerifier.create(connectorController.alterOffsets("test", "connect1", offsetsRequest))
                 .consumeNextWith(alterResponse -> {
-                    assertEquals(ConnectorOperation.RESET, alterResponse.getStatus().getCode());
+                    assertEquals(
+                            ConnectorOperation.RESET, alterResponse.getStatus().getCode());
                     assertEquals("connect1", alterResponse.getMetadata().getName());
                 })
                 .verifyComplete();

--- a/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
@@ -35,6 +35,7 @@ import com.michelin.ns4kafka.model.connect.ConnectorOffsetResponse;
 import com.michelin.ns4kafka.model.connect.ConnectorOperation;
 import com.michelin.ns4kafka.security.ResourceBasedSecurityRule;
 import com.michelin.ns4kafka.service.ConnectorService;
+import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsetsResponse;
 import com.michelin.ns4kafka.service.NamespaceService;
 import com.michelin.ns4kafka.service.ResourceQuotaService;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsetsResponse;

--- a/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
@@ -35,9 +35,9 @@ import com.michelin.ns4kafka.model.connect.ConnectorOffsetResponse;
 import com.michelin.ns4kafka.model.connect.ConnectorOperation;
 import com.michelin.ns4kafka.security.ResourceBasedSecurityRule;
 import com.michelin.ns4kafka.service.ConnectorService;
-import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsetsResponse;
 import com.michelin.ns4kafka.service.NamespaceService;
 import com.michelin.ns4kafka.service.ResourceQuotaService;
+import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsets;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsetsResponse;
 import com.michelin.ns4kafka.util.exception.ResourceValidationException;
 import com.michelin.ns4kafka.validation.ValidationResult;
@@ -1195,43 +1195,6 @@ class ConnectorControllerTest {
     }
 
     @Test
-    void shouldStopConnector() {
-        Namespace ns = Namespace.builder()
-                .metadata(Resource.Metadata.builder()
-                        .name("test")
-                        .cluster("local")
-                        .build())
-                .build();
-
-        Connector connector = Connector.builder()
-                .metadata(Resource.Metadata.builder().name("connect1").build())
-                .build();
-
-        when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
-        when(connectorService.isNamespaceOwnerOfConnect(ns, "connect1")).thenReturn(true);
-        when(connectorService.findByName(ns, "connect1")).thenReturn(Optional.of(connector));
-        when(connectorService.stop(ArgumentMatchers.any(), ArgumentMatchers.any()))
-                .thenReturn(Mono.just(HttpResponse.accepted()));
-
-        ChangeConnectorState changeConnectorState = ChangeConnectorState.builder()
-                .metadata(Resource.Metadata.builder().name("connect1").build())
-                .spec(ChangeConnectorState.ChangeConnectorStateSpec.builder()
-                        .action(ChangeConnectorState.ConnectorAction.STOP)
-                        .build())
-                .build();
-
-        StepVerifier.create(connectorController.changeState("test", "connect1", changeConnectorState))
-                .consumeNextWith(response -> {
-                    assertTrue(response.getBody().isPresent());
-                    assertTrue(response.getBody().get().getStatus().isSuccess());
-                    assertEquals(
-                            HttpStatus.ACCEPTED, response.body().getStatus().getCode());
-                    assertEquals("connect1", response.body().getMetadata().getName());
-                })
-                .verifyComplete();
-    }
-
-    @Test
     void shouldNotResetConnectorOffsetsWhenNotOwned() {
         Namespace ns = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
@@ -1307,8 +1270,8 @@ class ConnectorControllerTest {
                 .verifyComplete();
     }
 
-    @Test
-    void shouldNotResetConnectorOffsetsWhenError() {
+        @Test
+        void shouldNotResetConnectorOffsetsWhenError() {
         Namespace ns = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
                         .name("test")
@@ -1333,5 +1296,35 @@ class ConnectorControllerTest {
                     assertEquals("Rebalancing", error.getMessage());
                 })
                 .verify();
+    }
+
+    @Test
+    void shouldAlterConnectorOffsets() {
+        Namespace ns = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("test")
+                        .cluster("local")
+                        .build())
+                .build();
+
+        Connector connector = Connector.builder()
+                .metadata(Resource.Metadata.builder().name("connect1").build())
+                .build();
+
+        ConnectorOffsets offsetsRequest = new ConnectorOffsets(List.of(new ConnectorOffsets.ConnectorOffset(
+                Map.of("kafka_topic", "topic1", "kafka_partition", 0), null)));
+
+        when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
+        when(connectorService.isNamespaceOwnerOfConnect(ns, "connect1")).thenReturn(true);
+        when(connectorService.findByName(ns, "connect1")).thenReturn(Optional.of(connector));
+        when(connectorService.alterOffsets(ns, connector, offsetsRequest))
+                .thenReturn(Mono.just(HttpResponse.ok(new ConnectorOffsetsResponse("alter ok"))));
+
+        StepVerifier.create(connectorController.alterOffsets("test", "connect1", offsetsRequest))
+                .consumeNextWith(alterResponse -> {
+                    assertEquals(ConnectorOperation.RESET, alterResponse.getStatus().getCode());
+                    assertEquals("connect1", alterResponse.getMetadata().getName());
+                })
+                .verifyComplete();
     }
 }

--- a/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
@@ -1195,6 +1195,42 @@ class ConnectorControllerTest {
     }
 
     @Test
+    void shouldStopConnector() {
+        Namespace ns = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("test")
+                        .cluster("local")
+                        .build())
+                .build();
+
+        Connector connector = Connector.builder()
+                .metadata(Resource.Metadata.builder().name("connect1").build())
+                .build();
+
+        when(namespaceService.findByName("test")).thenReturn(Optional.of(ns));
+        when(connectorService.isNamespaceOwnerOfConnect(ns, "connect1")).thenReturn(true);
+        when(connectorService.findByName(ns, "connect1")).thenReturn(Optional.of(connector));
+        when(connectorService.stop(ArgumentMatchers.any(), ArgumentMatchers.any()))
+                .thenReturn(Mono.just(HttpResponse.accepted()));
+
+        ChangeConnectorState changeConnectorState = ChangeConnectorState.builder()
+                .metadata(Resource.Metadata.builder().name("connect1").build())
+                .spec(ChangeConnectorState.ChangeConnectorStateSpec.builder()
+                        .action(ChangeConnectorState.ConnectorAction.STOP)
+                        .build())
+                .build();
+
+        StepVerifier.create(connectorController.changeState("test", "connect1", changeConnectorState))
+                .consumeNextWith(response -> {
+                    assertTrue(response.getBody().isPresent());
+                    assertTrue(response.getBody().get().getStatus().isSuccess());
+                    assertEquals(HttpStatus.ACCEPTED, response.body().getStatus().getCode());
+                    assertEquals("connect1", response.body().getMetadata().getName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
     void shouldNotResetConnectorOffsetsWhenNotOwned() {
         Namespace ns = Namespace.builder()
                 .metadata(Resource.Metadata.builder()

--- a/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/connect/ConnectorControllerTest.java
@@ -1224,7 +1224,8 @@ class ConnectorControllerTest {
                 .consumeNextWith(response -> {
                     assertTrue(response.getBody().isPresent());
                     assertTrue(response.getBody().get().getStatus().isSuccess());
-                    assertEquals(HttpStatus.ACCEPTED, response.body().getStatus().getCode());
+                    assertEquals(
+                            HttpStatus.ACCEPTED, response.body().getStatus().getCode());
                     assertEquals("connect1", response.body().getMetadata().getName());
                 })
                 .verifyComplete();

--- a/src/test/java/com/michelin/ns4kafka/integration/ConnectorIntegrationTest.java
+++ b/src/test/java/com/michelin/ns4kafka/integration/ConnectorIntegrationTest.java
@@ -48,6 +48,7 @@ import com.michelin.ns4kafka.model.connect.Connector;
 import com.michelin.ns4kafka.model.connect.ConnectorOperation;
 import com.michelin.ns4kafka.model.connect.ConnectorResetOffsetsResponse;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorInfo;
+import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsets;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorSpecs;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorStateInfo;
 import com.michelin.ns4kafka.service.client.connect.entities.ServerInfo;
@@ -906,6 +907,91 @@ class ConnectorIntegrationTest extends KafkaConnectIntegrationTest {
         assertTrue(resetResponse.getBody().isPresent());
         assertNotNull(resetResponse.body());
         assertEquals(ConnectorOperation.RESET, resetResponse.body().getStatus().getCode());
+    }
+
+    @Test
+    void shouldAlterConnectorOffsets() throws InterruptedException {
+        Topic topic = Topic.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns1-topic-alter-offsets")
+                        .namespace("ns1")
+                        .build())
+                .spec(Topic.TopicSpec.builder()
+                        .partitions(3)
+                        .replicationFactor(1)
+                        .configs(
+                                Map.of("cleanup.policy", "delete", "min.insync.replicas", "1", "retention.ms", "60000"))
+                        .build())
+                .build();
+
+        Connector connector = Connector.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns1-connector-alter-offsets")
+                        .namespace("ns1")
+                        .build())
+                .spec(Connector.ConnectorSpec.builder()
+                        .connectCluster("test-connect")
+                        .config(Map.of(
+                                "connector.class", "org.apache.kafka.connect.file.FileStreamSinkConnector",
+                                "tasks.max", "1",
+                                "topics", "ns1-topic-alter-offsets"))
+                        .build())
+                .build();
+
+        ns4KafkaClient
+                .toBlocking()
+                .exchange(HttpRequest.create(HttpMethod.POST, "/api/namespaces/ns1/topics")
+                        .bearerAuth(token)
+                        .body(topic));
+
+        topicAsyncExecutorList.forEach(TopicAsyncExecutor::run);
+        ns4KafkaClient
+                .toBlocking()
+                .exchange(HttpRequest.create(HttpMethod.POST, "/api/namespaces/ns1/connectors")
+                        .bearerAuth(token)
+                        .body(connector));
+
+        forceConnectorSynchronization();
+        waitForConnectorToBeInState("ns1-connector-alter-offsets", "RUNNING");
+
+        ChangeConnectorState stopState = ChangeConnectorState.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns1-connector-alter-offsets")
+                        .build())
+                .spec(ChangeConnectorState.ChangeConnectorStateSpec.builder()
+                        .action(ChangeConnectorState.ConnectorAction.STOP)
+                        .build())
+                .build();
+
+        HttpResponse<ChangeConnectorState> stopResponse = ns4KafkaClient
+                .toBlocking()
+                .exchange(HttpRequest.create(
+                                HttpMethod.POST,
+                                "/api/namespaces/ns1/connectors/ns1-connector-alter-offsets/change-state")
+                        .bearerAuth(token)
+                        .body(stopState));
+
+        assertEquals(HttpStatus.OK, stopResponse.status());
+
+        waitForConnectorToBeInState("ns1-connector-alter-offsets", "STOPPED");
+
+        ConnectorOffsets offsetsRequest = new ConnectorOffsets(List.of(new ConnectorOffsets.ConnectorOffset(
+                Map.of("kafka_topic", "ns1-topic-alter-offsets", "kafka_partition", 0), null)));
+
+        HttpResponse<ConnectorResetOffsetsResponse> alterResponse = ns4KafkaClient
+                .toBlocking()
+                .exchange(
+                        HttpRequest.create(
+                                        HttpMethod.PATCH,
+                                        "/api/namespaces/ns1/connectors/ns1-connector-alter-offsets/offsets")
+                                .bearerAuth(token)
+                                .body(offsetsRequest),
+                        ConnectorResetOffsetsResponse.class);
+
+        assertEquals(HttpStatus.OK, alterResponse.status());
+        assertTrue(alterResponse.getBody().isPresent());
+        assertNotNull(alterResponse.body());
+        assertEquals(ConnectorOperation.RESET, alterResponse.body().getStatus().getCode());
     }
 
     @Test

--- a/src/test/java/com/michelin/ns4kafka/integration/ConnectorIntegrationTest.java
+++ b/src/test/java/com/michelin/ns4kafka/integration/ConnectorIntegrationTest.java
@@ -982,7 +982,7 @@ class ConnectorIntegrationTest extends KafkaConnectIntegrationTest {
                 .toBlocking()
                 .exchange(
                         HttpRequest.create(
-                                        HttpMethod.PATCH,
+                                        HttpMethod.POST,
                                         "/api/namespaces/ns1/connectors/ns1-connector-alter-offsets/offsets")
                                 .bearerAuth(token)
                                 .body(offsetsRequest),

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
@@ -1424,9 +1424,8 @@ class ConnectorServiceTest {
                         .build())
                 .build();
 
-        ConnectorOffsets offsetsRequest =
-                new ConnectorOffsets(List.of(new ConnectorOffsets.ConnectorOffset(
-                        Map.of("kafka_topic", "topic1", "kafka_partition", 0), null)));
+        ConnectorOffsets offsetsRequest = new ConnectorOffsets(List.of(
+                new ConnectorOffsets.ConnectorOffset(Map.of("kafka_topic", "topic1", "kafka_partition", 0), null)));
 
         when(kafkaConnectClient.alterOffsets(
                         namespace.getMetadata().getCluster(),

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
@@ -44,7 +44,6 @@ import com.michelin.ns4kafka.service.client.connect.entities.ConnectorInfo;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsets;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsetsResponse;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorPluginInfo;
-import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsetsResponse;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorStateInfo;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorStatus;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorType;
@@ -1407,5 +1406,47 @@ class ConnectorServiceTest {
                         namespace.getMetadata().getCluster(),
                         connector.getSpec().getConnectCluster(),
                         connector.getMetadata().getName());
+    }
+
+    @Test
+    void shouldAlterConnectorOffsets() {
+        Namespace namespace = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("namespace")
+                        .cluster("local")
+                        .build())
+                .build();
+
+        Connector connector = Connector.builder()
+                .metadata(Resource.Metadata.builder().name("ns-connect1").build())
+                .spec(Connector.ConnectorSpec.builder()
+                        .connectCluster("local-name")
+                        .build())
+                .build();
+
+        ConnectorOffsets offsetsRequest =
+                new ConnectorOffsets(List.of(new ConnectorOffsets.ConnectorOffset(
+                        Map.of("kafka_topic", "topic1", "kafka_partition", 0), null)));
+
+        when(kafkaConnectClient.alterOffsets(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName(),
+                        offsetsRequest))
+                .thenReturn(Mono.just(HttpResponse.ok(new ConnectorOffsetsResponse("alter ok"))));
+
+        StepVerifier.create(connectorService.alterOffsets(namespace, connector, offsetsRequest))
+                .consumeNextWith(response -> {
+                    assertEquals(HttpStatus.OK, response.getStatus());
+                    assertEquals("alter ok", response.body().message());
+                })
+                .verifyComplete();
+
+        verify(kafkaConnectClient)
+                .alterOffsets(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName(),
+                        offsetsRequest);
     }
 }

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
@@ -44,6 +44,7 @@ import com.michelin.ns4kafka.service.client.connect.entities.ConnectorInfo;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsets;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsetsResponse;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorPluginInfo;
+import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsetsResponse;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorStateInfo;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorStatus;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorType;


### PR DESCRIPTION
## Context

This PR adds support for altering connector offsets through Ns4Kafka.

The fully reset offsets flow was introduced previously in https://github.com/michelin/ns4kafka/pull/821. This change extends that work by supporting partial or targeted offset updates through the Kafka Connect alter offsets API.

The goal is to allow users to go beyond a full reset and send an offsets payload when they need finer control over connector offsets.

## Proposed solution

I introduced a dedicated API flow for connector alter offsets through:

`POST /api/namespaces/{namespace}/connectors/{connector}/offsets`

This keeps the endpoint aligned with the existing dedicated reset offsets endpoint while making it possible to send a request body describing the offsets to alter.

## Implementation

I added a new request payload model to represent the Kafka Connect alter offsets body.

I then wired the new flow through the existing Ns4Kafka layers:

- controller endpoint to receive the patch request
- service method to delegate the operation
- Kafka Connect client call to invoke `PATCH /connectors/{connector}/offsets`

The implementation follows the same ownership and existence checks already used for connector administrative actions.

## Tests

I added coverage for the new alter offsets flow at multiple levels:

- controller test for the dedicated patch endpoint
- service test for the new delegation path
- integration test covering the end-to-end connector alter offsets flow

These tests validate that the request is accepted, routed correctly, and that the Kafka Connect response is returned back by Ns4Kafka.

## Remark

Together with https://github.com/michelin/ns4kafka/pull/821, Ns4Kafka now supports both full offset reset and offset alteration flows for connectors.
