### PR TITLE
Make AKHQ claim API ignore Transactional ID ACLs

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/controller/AkhqController.java
+++ b/src/main/java/com/michelin/ns4kafka/controller/AkhqController.java
@@ -96,9 +96,6 @@ public class AkhqController {
 
         List<AccessControlEntry> relatedAcl = getAclsByGroups(groups);
 
-        // Add all public ACLs.
-        relatedAcl.addAll(aclService.findAllPublicGrantedTo());
-
         return AkhqClaimResponseV2.builder()
                 .roles(ns4KafkaProperties.getAkhq().getFormerRoles())
                 .topicsFilterRegexp(
@@ -124,9 +121,6 @@ public class AkhqController {
         }
 
         List<AccessControlEntry> acls = getAclsByGroups(groups);
-
-        // Add all public ACLs
-        acls.addAll(aclService.findAllPublicGrantedTo());
 
         // Remove unnecessary ACLs
         // E.g., project.topic1 when project.* is granted on the same resource type and cluster
@@ -294,7 +288,7 @@ public class AkhqController {
                                                 ns4KafkaProperties.getAkhq().getGroupLabel(), "_")
                                         .toLowerCase()
                                         .split(ns4KafkaProperties.getAkhq().getGroupDelimiter()))))
-                .flatMap(namespace -> aclService.findAllGrantedToNamespace(namespace).stream())
+                .flatMap(namespace -> aclService.findNonTransactionalGrantedToNamespace(namespace).stream())
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/michelin/ns4kafka/service/AclService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/AclService.java
@@ -526,13 +526,18 @@ public class AclService {
     }
 
     /**
-     * Find all public granted ACLs.
+     * Find all ACLs granted to a given namespace. Will also return public granted ACLs.
      *
+     * @param namespace The namespace
      * @return A list of ACLs
      */
-    public List<AccessControlEntry> findAllPublicGrantedTo() {
-        return accessControlEntryRepository.findAll().stream()
-                .filter(this::isPublicAcl)
+    public List<AccessControlEntry> findNonTransactionalGrantedToNamespace(Namespace namespace) {
+        return findAllForCluster(namespace.getMetadata().getCluster()).stream()
+                .filter(acl -> isPublicAcl(acl)
+                        || acl.getSpec()
+                                .getGrantedTo()
+                                .equals(namespace.getMetadata().getName()))
+                .filter(acl -> !acl.getSpec().getResourceType().equals(TRANSACTIONAL_ID))
                 .toList();
     }
 

--- a/src/main/java/com/michelin/ns4kafka/service/AclService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/AclService.java
@@ -526,7 +526,7 @@ public class AclService {
     }
 
     /**
-     * Find all ACLs granted to a given namespace. Will also return public granted ACLs.
+     * Find non-transactional ID ACLs granted to a given namespace, including public granted ACLs.
      *
      * @param namespace The namespace
      * @return A list of ACLs

--- a/src/test/java/com/michelin/ns4kafka/controller/AkhqControllerTest.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/AkhqControllerTest.java
@@ -219,9 +219,9 @@ class AkhqControllerTest {
 
         when(ns4KafkaProperties.getAkhq()).thenReturn(buildAkhqProperties());
         when(namespaceService.findAll()).thenReturn(List.of(ns1, ns2, ns3, ns4, ns5));
-        when(aclService.findAllGrantedToNamespace(ns1)).thenReturn(List.of(ns1Ace1, ns1Ace2, pubAce1));
-        when(aclService.findAllGrantedToNamespace(ns2)).thenReturn(List.of(ns2Ace1, ns2Ace2, pubAce1));
-        when(aclService.findAllGrantedToNamespace(ns3)).thenReturn(List.of(ns3Ace1, pubAce1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1)).thenReturn(List.of(ns1Ace1, ns1Ace2, pubAce1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns2)).thenReturn(List.of(ns2Ace1, ns2Ace2, pubAce1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns3)).thenReturn(List.of(ns3Ace1, pubAce1));
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1-SUPPORT", "GP-PROJECT2-SUPPORT"))
@@ -247,12 +247,11 @@ class AkhqControllerTest {
                         "^\\Qproject3_topic\\E$"),
                 actual.getTopicsFilterRegexp());
 
-        verify(aclService).findAllGrantedToNamespace(ns1);
-        verify(aclService).findAllGrantedToNamespace(ns2);
-        verify(aclService).findAllGrantedToNamespace(ns3);
-        verify(aclService, never()).findAllGrantedToNamespace(ns4);
-        verify(aclService, never()).findAllGrantedToNamespace(ns5);
-        verify(aclService).findAllPublicGrantedTo();
+        verify(aclService).findNonTransactionalGrantedToNamespace(ns1);
+        verify(aclService).findNonTransactionalGrantedToNamespace(ns2);
+        verify(aclService).findNonTransactionalGrantedToNamespace(ns3);
+        verify(aclService, never()).findNonTransactionalGrantedToNamespace(ns4);
+        verify(aclService, never()).findNonTransactionalGrantedToNamespace(ns5);
     }
 
     @Test

--- a/src/test/java/com/michelin/ns4kafka/controller/AkhqControllerV3Test.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/AkhqControllerV3Test.java
@@ -105,7 +105,7 @@ class AkhqControllerV3Test {
                 .thenReturn(
                         Stream.of(new ManagedClusterProperties("cluster1"), new ManagedClusterProperties("cluster2")));
         when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1));
-        when(aclService.findAllGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1-SUPPORT"))
@@ -161,7 +161,8 @@ class AkhqControllerV3Test {
         when(ns4KafkaProperties.getAkhq()).thenReturn(buildAkhqProperties());
         when(managedClusters.stream()).thenReturn(Stream.of(new ManagedClusterProperties("cluster2")));
         when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1));
-        when(aclService.findAllGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1, ace2Ns1Cluster1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1))
+                .thenReturn(List.of(ace1Ns1Cluster1, ace2Ns1Cluster1));
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1-SUPPORT"))
@@ -208,7 +209,7 @@ class AkhqControllerV3Test {
                 .thenReturn(
                         Stream.of(new ManagedClusterProperties("cluster1"), new ManagedClusterProperties("cluster2")));
         when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1));
-        when(aclService.findAllGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1-SUPPORT"))
@@ -257,7 +258,7 @@ class AkhqControllerV3Test {
                 .thenReturn(
                         Stream.of(new ManagedClusterProperties("cluster1"), new ManagedClusterProperties("cluster2")));
         when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1));
-        when(aclService.findAllGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1-SUPPORT"))
@@ -336,7 +337,7 @@ class AkhqControllerV3Test {
 
         Namespace ns1Cluster2 = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
-                        .name("ns1")
+                        .name("ns2")
                         .cluster("cluster2")
                         .labels(Map.of("support-group", "GP-PROJECT1-SUPPORT"))
                         .build())
@@ -351,6 +352,7 @@ class AkhqControllerV3Test {
                         .resourceType(AccessControlEntry.ResourceType.TOPIC)
                         .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
                         .resource("project1_t.")
+                        .grantedTo("ns1")
                         .build())
                 .build();
 
@@ -359,7 +361,7 @@ class AkhqControllerV3Test {
                 .thenReturn(
                         Stream.of(new ManagedClusterProperties("cluster1"), new ManagedClusterProperties("cluster2")));
         when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1, ns1Cluster2));
-        when(aclService.findAllGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
 
         AccessControlEntry ace1Ns1Cluster2 = AccessControlEntry.builder()
                 .metadata(Resource.Metadata.builder()
@@ -370,10 +372,11 @@ class AkhqControllerV3Test {
                         .resourceType(AccessControlEntry.ResourceType.TOPIC)
                         .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
                         .resource("project1_t.")
+                        .grantedTo("ns2")
                         .build())
                 .build();
 
-        when(aclService.findAllGrantedToNamespace(ns1Cluster2)).thenReturn(List.of(ace1Ns1Cluster2));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster2)).thenReturn(List.of(ace1Ns1Cluster2));
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1-SUPPORT"))
@@ -419,6 +422,7 @@ class AkhqControllerV3Test {
                         .resourceType(AccessControlEntry.ResourceType.TOPIC)
                         .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
                         .resource("project1_t.")
+                        .grantedTo("ns1")
                         .build())
                 .build();
 
@@ -427,7 +431,7 @@ class AkhqControllerV3Test {
                 .thenReturn(
                         Stream.of(new ManagedClusterProperties("cluster1"), new ManagedClusterProperties("cluster2")));
         when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1, ns2Cluster1));
-        when(aclService.findAllGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
 
         AccessControlEntry ace2Ns2Cluster1 = AccessControlEntry.builder()
                 .metadata(Resource.Metadata.builder()
@@ -438,10 +442,11 @@ class AkhqControllerV3Test {
                         .resourceType(AccessControlEntry.ResourceType.TOPIC)
                         .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
                         .resource("project2_t.")
+                        .grantedTo("ns2")
                         .build())
                 .build();
 
-        when(aclService.findAllGrantedToNamespace(ns2Cluster1)).thenReturn(List.of(ace2Ns2Cluster1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns2Cluster1)).thenReturn(List.of(ace2Ns2Cluster1));
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1&2-SUPPORT"))
@@ -474,7 +479,7 @@ class AkhqControllerV3Test {
 
         Namespace ns1Cluster2 = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
-                        .name("ns1")
+                        .name("ns2")
                         .cluster("cluster2")
                         .labels(Map.of("support-group", "GP-PROJECT1-SUPPORT"))
                         .build())
@@ -497,7 +502,7 @@ class AkhqControllerV3Test {
                 .thenReturn(
                         Stream.of(new ManagedClusterProperties("cluster1"), new ManagedClusterProperties("cluster2")));
         when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1, ns1Cluster2));
-        when(aclService.findAllGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Cluster1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Cluster1));
 
         AccessControlEntry ace1Cluster2 = AccessControlEntry.builder()
                 .metadata(Resource.Metadata.builder()
@@ -511,7 +516,7 @@ class AkhqControllerV3Test {
                         .build())
                 .build();
 
-        when(aclService.findAllGrantedToNamespace(ns1Cluster2)).thenReturn(List.of(ace1Cluster2));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster2)).thenReturn(List.of(ace1Cluster2));
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1-SUPPORT"))
@@ -557,6 +562,7 @@ class AkhqControllerV3Test {
                         .resourceType(AccessControlEntry.ResourceType.TOPIC)
                         .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
                         .resource("project1_t.")
+                        .grantedTo("ns1")
                         .build())
                 .build();
 
@@ -565,7 +571,7 @@ class AkhqControllerV3Test {
                 .thenReturn(
                         Stream.of(new ManagedClusterProperties("cluster1"), new ManagedClusterProperties("cluster2")));
         when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1, ns2Cluster2));
-        when(aclService.findAllGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
 
         AccessControlEntry ace1Ns2Cluster2 = AccessControlEntry.builder()
                 .metadata(Resource.Metadata.builder()
@@ -576,10 +582,11 @@ class AkhqControllerV3Test {
                         .resourceType(AccessControlEntry.ResourceType.TOPIC)
                         .resourcePatternType(AccessControlEntry.ResourcePatternType.PREFIXED)
                         .resource("project2_t.")
+                        .grantedTo("ns2")
                         .build())
                 .build();
 
-        when(aclService.findAllGrantedToNamespace(ns2Cluster2)).thenReturn(List.of(ace1Ns2Cluster2));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns2Cluster2)).thenReturn(List.of(ace1Ns2Cluster2));
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1&2-SUPPORT"))
@@ -733,7 +740,7 @@ class AkhqControllerV3Test {
                 .thenReturn(
                         Stream.of(new ManagedClusterProperties("cluster1"), new ManagedClusterProperties("cluster2")));
         when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1));
-        when(aclService.findAllGrantedToNamespace(ns1Cluster1)).thenReturn(inputAcls);
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1)).thenReturn(inputAcls);
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1&2-SUPPORT"))
@@ -853,7 +860,7 @@ class AkhqControllerV3Test {
                         new ManagedClusterProperties("cluster3"),
                         new ManagedClusterProperties("cluster4")));
         when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1));
-        when(aclService.findAllGrantedToNamespace(ns1Cluster1)).thenReturn(inputAcls);
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1)).thenReturn(inputAcls);
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1&2-SUPPORT"))
@@ -938,7 +945,7 @@ class AkhqControllerV3Test {
                 .thenReturn(
                         Stream.of(new ManagedClusterProperties("cluster"), new ManagedClusterProperties("cluster2")));
         when(namespaceService.findAll()).thenReturn(List.of(ns));
-        when(aclService.findAllGrantedToNamespace(ns)).thenReturn(inputAcls);
+        when(aclService.findNonTransactionalGrantedToNamespace(ns)).thenReturn(inputAcls);
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT-SUPPORT"))
@@ -1002,8 +1009,8 @@ class AkhqControllerV3Test {
         when(ns4KafkaProperties.getAkhq()).thenReturn(buildAkhqProperties());
         when(managedClusters.stream()).thenReturn(Stream.of(new ManagedClusterProperties("cluster")));
         when(namespaceService.findAll()).thenReturn(List.of(ns1, ns2));
-        when(aclService.findAllGrantedToNamespace(ns1)).thenReturn(acls1);
-        when(aclService.findAllGrantedToNamespace(ns2)).thenReturn(acls2);
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1)).thenReturn(acls1);
+        when(aclService.findNonTransactionalGrantedToNamespace(ns2)).thenReturn(acls2);
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT-SUPPORT"))

--- a/src/test/java/com/michelin/ns4kafka/controller/AkhqControllerV3Test.java
+++ b/src/test/java/com/michelin/ns4kafka/controller/AkhqControllerV3Test.java
@@ -335,7 +335,7 @@ class AkhqControllerV3Test {
                         .build())
                 .build();
 
-        Namespace ns1Cluster2 = Namespace.builder()
+        Namespace ns2Cluster2 = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
                         .name("ns2")
                         .cluster("cluster2")
@@ -343,7 +343,7 @@ class AkhqControllerV3Test {
                         .build())
                 .build();
 
-        AccessControlEntry ace1Ns1Cluster1 = AccessControlEntry.builder()
+        AccessControlEntry acl1 = AccessControlEntry.builder()
                 .metadata(Resource.Metadata.builder()
                         .name("acl")
                         .cluster("cluster1")
@@ -360,10 +360,10 @@ class AkhqControllerV3Test {
         when(managedClusters.stream())
                 .thenReturn(
                         Stream.of(new ManagedClusterProperties("cluster1"), new ManagedClusterProperties("cluster2")));
-        when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1, ns1Cluster2));
-        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(ace1Ns1Cluster1));
+        when(namespaceService.findAll()).thenReturn(List.of(ns1Cluster1, ns2Cluster2));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster1)).thenReturn(List.of(acl1));
 
-        AccessControlEntry ace1Ns1Cluster2 = AccessControlEntry.builder()
+        AccessControlEntry acl2 = AccessControlEntry.builder()
                 .metadata(Resource.Metadata.builder()
                         .name("acl")
                         .cluster("cluster2")
@@ -376,7 +376,7 @@ class AkhqControllerV3Test {
                         .build())
                 .build();
 
-        when(aclService.findNonTransactionalGrantedToNamespace(ns1Cluster2)).thenReturn(List.of(ace1Ns1Cluster2));
+        when(aclService.findNonTransactionalGrantedToNamespace(ns2Cluster2)).thenReturn(List.of(acl2));
 
         AkhqController.AkhqClaimRequest request = AkhqController.AkhqClaimRequest.builder()
                 .groups(List.of("GP-PROJECT1-SUPPORT"))

--- a/src/test/java/com/michelin/ns4kafka/service/AclServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/AclServiceTest.java
@@ -949,38 +949,6 @@ class AclServiceTest {
     }
 
     @Test
-    void shouldFindAllAclsGrantedToAll() {
-        AccessControlEntry ace1 = AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .grantedTo("namespace1")
-                        .build())
-                .build();
-
-        AccessControlEntry ace2 = AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .grantedTo("namespace1")
-                        .build())
-                .build();
-
-        AccessControlEntry ace3 = AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .grantedTo("namespace2")
-                        .build())
-                .build();
-
-        AccessControlEntry ace4 = AccessControlEntry.builder()
-                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
-                        .grantedTo("*")
-                        .build())
-                .build();
-
-        when(accessControlEntryRepository.findAll()).thenReturn(List.of(ace1, ace2, ace3, ace4));
-
-        List<AccessControlEntry> actual = aclService.findAllPublicGrantedTo();
-        assertEquals(1, actual.size());
-    }
-
-    @Test
     void shouldFindAllAclForNamespace() {
         Namespace ns = Namespace.builder()
                 .metadata(Resource.Metadata.builder()
@@ -1748,6 +1716,98 @@ class AclServiceTest {
                 aclService.findResourceOwnerGrantedToNamespace(ns, AccessControlEntry.ResourceType.CONNECT));
         assertEquals(
                 List.of(), aclService.findResourceOwnerGrantedToNamespace(ns, AccessControlEntry.ResourceType.GROUP));
+    }
+
+    @Test
+    void shouldFindNonTransactionalAclGrantedToNamespace() {
+        AccessControlEntry acl1 = AccessControlEntry.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns1-acl-topic")
+                        .namespace("namespace1")
+                        .cluster("local")
+                        .build())
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
+                        .permission(AccessControlEntry.Permission.OWNER)
+                        .grantedTo("namespace1")
+                        .build())
+                .build();
+
+        AccessControlEntry acl2 = AccessControlEntry.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("acl-ns2-read-to-all")
+                        .namespace("namespace2")
+                        .cluster("local")
+                        .build())
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
+                        .permission(AccessControlEntry.Permission.READ)
+                        .grantedTo("*")
+                        .build())
+                .build();
+
+        AccessControlEntry acl3 = AccessControlEntry.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns1-acl-connect")
+                        .namespace("namespace1")
+                        .cluster("local")
+                        .build())
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.CONNECT)
+                        .permission(AccessControlEntry.Permission.OWNER)
+                        .grantedTo("namespace1")
+                        .build())
+                .build();
+
+        AccessControlEntry acl4 = AccessControlEntry.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns2-acl-topic")
+                        .namespace("namespace2")
+                        .cluster("local")
+                        .build())
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.TOPIC)
+                        .permission(AccessControlEntry.Permission.OWNER)
+                        .grantedTo("namespace2")
+                        .build())
+                .build();
+
+        AccessControlEntry acl5 = AccessControlEntry.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns3-write-trans-acl-all")
+                        .namespace("namespace3")
+                        .cluster("local")
+                        .build())
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.TRANSACTIONAL_ID)
+                        .permission(AccessControlEntry.Permission.WRITE)
+                        .grantedTo("*")
+                        .build())
+                .build();
+
+        AccessControlEntry acl6 = AccessControlEntry.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("ns3-owner-trans-acl-ns1")
+                        .namespace("namespace3")
+                        .cluster("local")
+                        .build())
+                .spec(AccessControlEntry.AccessControlEntrySpec.builder()
+                        .resourceType(AccessControlEntry.ResourceType.TRANSACTIONAL_ID)
+                        .permission(AccessControlEntry.Permission.OWNER)
+                        .grantedTo("namespace1")
+                        .build())
+                .build();
+
+        when(accessControlEntryRepository.findAll()).thenReturn(List.of(acl1, acl2, acl3, acl4, acl5, acl6));
+
+        Namespace ns = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("namespace1")
+                        .cluster("local")
+                        .build())
+                .build();
+
+        assertEquals(List.of(acl1, acl2, acl3), aclService.findNonTransactionalGrantedToNamespace(ns));
     }
 
     @Test


### PR DESCRIPTION
## Context
Due to the rework on all executors to make Ns4kafka scalable, transactional ID mechanics in the ACL executor (and Confluent Role Bindings executor) cannot be kept. This mechanic is working as follow:
- It converts each group ACL to 2 Transactional ID ACLs (WRITE & DESCRIBE)
- If the namespace is authorizing transactions with `TransactionsEnabled = true`, it creates additional 2 Transactional ID ACLs (WRITE & DESCRIBE) for each group ACL

The goal is to handle manually Transactional ID ACLs (kafkactl apply / delete).
Prerequisite: 
- Transactional ID ACLs breaks the AKHQ claim API because this type is not handled properly. The API needs to be fixed.

## Proposed solution
- The Transactional ID ACLs are excluded when retrieving the ACLs in the AKHQ claim API.

## Additional update
- Public ACLs are retrieving with one query instead of 2.