### PR TITLE
Add consumer-groups resource types to role binding 

### DIFF
--- a/.docker/resources/admin/another-namespace.yml
+++ b/.docker/resources/admin/another-namespace.yml
@@ -71,7 +71,9 @@ spec:
     - "connect-clusters"
     - "connect-clusters/vaults"
     - "acls"
+    - "consumer-groups"
     - "consumer-groups/reset"
+    - "consumer-groups/external"
     - "streams"
     verbs:
     - "GET"

--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ The delivered JWT token will have the following format:
         "connectors",
         "connectors/change-state",
         "acls",
+        "consumer-groups",
         "consumer-groups/reset",
+        "consumer-groups/external",
         "streams",
         "connect-clusters",
         "connect-clusters/vaults"


### PR DESCRIPTION
Add consumer-groups resource types to role binding 

Add the "consumer-groups" and "consumer-groups/external" resource types
alongside "consumer-groups/reset" in the README JWT example and the
another-namespace.yml role binding, so users can get, delete and list
external consumer groups following the v1.21.1 pattern.