### PR TITLE
Add latest offsets and lag to consumer group listing

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/model/consumer/group/ConsumerGroup.java
+++ b/src/main/java/com/michelin/ns4kafka/model/consumer/group/ConsumerGroup.java
@@ -25,8 +25,6 @@ import io.micronaut.serde.annotation.Serdeable;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -63,22 +61,10 @@ public class ConsumerGroup extends Resource {
     @Schema(description = "Server-side", accessMode = Schema.AccessMode.READ_ONLY)
     public static class ConsumerGroupStatus {
         private GroupState state;
-
-        @Builder.Default
-        private List<ConsumerGroupOffset> offsets = new ArrayList<>();
-    }
-
-    /** Consumer group committed offset. */
-    @Data
-    @Builder
-    @Serdeable
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class ConsumerGroupOffset {
         private String topic;
-        private int partition;
-        private long currentOffset;
-        private long logEndOffset;
-        private long lag;
+        private Integer partition;
+        private Long currentOffset;
+        private Long logEndOffset;
+        private Long lag;
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/model/consumer/group/ConsumerGroup.java
+++ b/src/main/java/com/michelin/ns4kafka/model/consumer/group/ConsumerGroup.java
@@ -78,5 +78,7 @@ public class ConsumerGroup extends Resource {
         private String topic;
         private int partition;
         private long currentOffset;
+        private long logEndOffset;
+        private long lag;
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/service/ConsumerGroupService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConsumerGroupService.java
@@ -104,15 +104,16 @@ public class ConsumerGroupService {
 
         boolean includeOffsets = consumerGroupIds.size() == 1;
         return consumerGroupIds.stream()
-                .map(groupId -> {
+                .flatMap(groupId -> {
                     Map<TopicPartition, Long> committedOffsets =
                             includeOffsets ? getCommittedOffsets(consumerGroupAsyncExecutor, groupId) : Map.of();
-                    return buildConsumerGroup(
+                    return buildConsumerGroups(
                             namespace,
                             groupId,
                             descriptions.get(groupId),
                             committedOffsets,
-                            getLogEndOffsets(consumerGroupAsyncExecutor, committedOffsets.keySet()));
+                            getLogEndOffsets(consumerGroupAsyncExecutor, committedOffsets.keySet()))
+                            .stream();
                 })
                 .toList();
     }
@@ -159,14 +160,15 @@ public class ConsumerGroupService {
                 consumerGroupAsyncExecutor.describeConsumerGroups(consumerGroupIds);
 
         return consumerGroupIds.stream()
-                .map(groupId -> {
+                .flatMap(groupId -> {
                     Map<TopicPartition, Long> committedOffsets = committedOffsetsByGroup.get(groupId);
-                    return buildConsumerGroup(
+                    return buildConsumerGroups(
                             namespace,
                             groupId,
                             descriptions.get(groupId),
                             committedOffsets,
-                            getLogEndOffsets(consumerGroupAsyncExecutor, committedOffsets.keySet()));
+                            getLogEndOffsets(consumerGroupAsyncExecutor, committedOffsets.keySet()))
+                            .stream();
                 })
                 .toList();
     }
@@ -395,45 +397,69 @@ public class ConsumerGroupService {
     }
 
     /**
-     * Build a consumer group resource.
+     * Build the flattened consumer group resources for a given group.
      *
      * @param namespace The namespace
      * @param consumerGroupId The consumer group
      * @param description The consumer group description
      * @param committedOffsets The committed offsets
      * @param logEndOffsets The log end offsets
-     * @return The consumer group
+     * @return The flattened consumer groups
      */
-    private ConsumerGroup buildConsumerGroup(
+    private List<ConsumerGroup> buildConsumerGroups(
             Namespace namespace,
             String consumerGroupId,
             ConsumerGroupDescription description,
             Map<TopicPartition, Long> committedOffsets,
             Map<TopicPartition, Long> logEndOffsets) {
+        GroupState state = description == null ? GroupState.UNKNOWN : description.groupState();
+
+        if (committedOffsets.isEmpty()) {
+            return List.of(buildConsumerGroup(
+                    namespace,
+                    consumerGroupId,
+                    ConsumerGroup.ConsumerGroupStatus.builder().state(state).build()));
+        }
+
+        return committedOffsets.entrySet().stream()
+                .sorted(comparing((Map.Entry<TopicPartition, Long> entry) ->
+                                entry.getKey().topic())
+                        .thenComparingInt(entry -> entry.getKey().partition()))
+                .map(entry -> {
+                    long currentOffset = entry.getValue();
+                    Long logEndOffset = logEndOffsets.get(entry.getKey());
+                    return buildConsumerGroup(
+                            namespace,
+                            consumerGroupId,
+                            ConsumerGroup.ConsumerGroupStatus.builder()
+                                    .state(state)
+                                    .topic(entry.getKey().topic())
+                                    .partition(entry.getKey().partition())
+                                    .currentOffset(currentOffset)
+                                    .logEndOffset(logEndOffset == null ? 0L : logEndOffset)
+                                    .lag(logEndOffset == null ? 0L : logEndOffset - currentOffset)
+                                    .build());
+                })
+                .toList();
+    }
+
+    /**
+     * Build a consumer group resource with the given status.
+     *
+     * @param namespace The namespace
+     * @param consumerGroupId The consumer group
+     * @param status The consumer group status
+     * @return The consumer group
+     */
+    private ConsumerGroup buildConsumerGroup(
+            Namespace namespace, String consumerGroupId, ConsumerGroup.ConsumerGroupStatus status) {
         return ConsumerGroup.builder()
                 .metadata(Resource.Metadata.builder()
                         .name(consumerGroupId)
                         .namespace(namespace.getMetadata().getName())
                         .cluster(namespace.getMetadata().getCluster())
                         .build())
-                .status(ConsumerGroup.ConsumerGroupStatus.builder()
-                        .state(description == null ? GroupState.UNKNOWN : description.groupState())
-                        .offsets(committedOffsets.entrySet().stream()
-                                .map(entry -> {
-                                    long currentOffset = entry.getValue();
-                                    Long logEndOffset = logEndOffsets.get(entry.getKey());
-                                    return ConsumerGroup.ConsumerGroupOffset.builder()
-                                            .topic(entry.getKey().topic())
-                                            .partition(entry.getKey().partition())
-                                            .currentOffset(currentOffset)
-                                            .logEndOffset(logEndOffset == null ? 0L : logEndOffset)
-                                            .lag(logEndOffset == null ? 0L : logEndOffset - currentOffset)
-                                            .build();
-                                })
-                                .sorted(comparing(ConsumerGroup.ConsumerGroupOffset::getTopic)
-                                        .thenComparingInt(ConsumerGroup.ConsumerGroupOffset::getPartition))
-                                .toList())
-                        .build())
+                .status(status)
                 .build();
     }
 

--- a/src/main/java/com/michelin/ns4kafka/service/ConsumerGroupService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConsumerGroupService.java
@@ -44,6 +44,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -103,11 +104,16 @@ public class ConsumerGroupService {
 
         boolean includeOffsets = consumerGroupIds.size() == 1;
         return consumerGroupIds.stream()
-                .map(groupId -> buildConsumerGroup(
-                        namespace,
-                        groupId,
-                        descriptions.get(groupId),
-                        includeOffsets ? getCommittedOffsets(consumerGroupAsyncExecutor, groupId) : Map.of()))
+                .map(groupId -> {
+                    Map<TopicPartition, Long> committedOffsets =
+                            includeOffsets ? getCommittedOffsets(consumerGroupAsyncExecutor, groupId) : Map.of();
+                    return buildConsumerGroup(
+                            namespace,
+                            groupId,
+                            descriptions.get(groupId),
+                            committedOffsets,
+                            getLogEndOffsets(consumerGroupAsyncExecutor, committedOffsets.keySet()));
+                })
                 .toList();
     }
 
@@ -153,8 +159,15 @@ public class ConsumerGroupService {
                 consumerGroupAsyncExecutor.describeConsumerGroups(consumerGroupIds);
 
         return consumerGroupIds.stream()
-                .map(groupId -> buildConsumerGroup(
-                        namespace, groupId, descriptions.get(groupId), committedOffsetsByGroup.get(groupId)))
+                .map(groupId -> {
+                    Map<TopicPartition, Long> committedOffsets = committedOffsetsByGroup.get(groupId);
+                    return buildConsumerGroup(
+                            namespace,
+                            groupId,
+                            descriptions.get(groupId),
+                            committedOffsets,
+                            getLogEndOffsets(consumerGroupAsyncExecutor, committedOffsets.keySet()));
+                })
                 .toList();
     }
 
@@ -388,13 +401,15 @@ public class ConsumerGroupService {
      * @param consumerGroupId The consumer group
      * @param description The consumer group description
      * @param committedOffsets The committed offsets
+     * @param logEndOffsets The log end offsets
      * @return The consumer group
      */
     private ConsumerGroup buildConsumerGroup(
             Namespace namespace,
             String consumerGroupId,
             ConsumerGroupDescription description,
-            Map<TopicPartition, Long> committedOffsets) {
+            Map<TopicPartition, Long> committedOffsets,
+            Map<TopicPartition, Long> logEndOffsets) {
         return ConsumerGroup.builder()
                 .metadata(Resource.Metadata.builder()
                         .name(consumerGroupId)
@@ -404,11 +419,17 @@ public class ConsumerGroupService {
                 .status(ConsumerGroup.ConsumerGroupStatus.builder()
                         .state(description == null ? GroupState.UNKNOWN : description.groupState())
                         .offsets(committedOffsets.entrySet().stream()
-                                .map(entry -> ConsumerGroup.ConsumerGroupOffset.builder()
-                                        .topic(entry.getKey().topic())
-                                        .partition(entry.getKey().partition())
-                                        .currentOffset(entry.getValue())
-                                        .build())
+                                .map(entry -> {
+                                    long currentOffset = entry.getValue();
+                                    Long logEndOffset = logEndOffsets.get(entry.getKey());
+                                    return ConsumerGroup.ConsumerGroupOffset.builder()
+                                            .topic(entry.getKey().topic())
+                                            .partition(entry.getKey().partition())
+                                            .currentOffset(currentOffset)
+                                            .logEndOffset(logEndOffset == null ? 0L : logEndOffset)
+                                            .lag(logEndOffset == null ? 0L : logEndOffset - currentOffset)
+                                            .build();
+                                })
                                 .sorted(comparing(ConsumerGroup.ConsumerGroupOffset::getTopic)
                                         .thenComparingInt(ConsumerGroup.ConsumerGroupOffset::getPartition))
                                 .toList())
@@ -427,6 +448,29 @@ public class ConsumerGroupService {
             ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor, String groupId) {
         try {
             return consumerGroupAsyncExecutor.getCommittedOffsets(groupId);
+        } catch (ExecutionException _) {
+            return Map.of();
+        } catch (InterruptedException _) {
+            Thread.currentThread().interrupt();
+            return Map.of();
+        }
+    }
+
+    /**
+     * Get the log end offsets for a given set of topic-partitions.
+     *
+     * @param consumerGroupAsyncExecutor The consumer group async executor
+     * @param partitions The topic-partitions
+     * @return The log end offsets
+     */
+    private Map<TopicPartition, Long> getLogEndOffsets(
+            ConsumerGroupAsyncExecutor consumerGroupAsyncExecutor, Set<TopicPartition> partitions) {
+        if (partitions.isEmpty()) {
+            return Map.of();
+        }
+
+        try {
+            return consumerGroupAsyncExecutor.getLogEndOffsets(new ArrayList<>(partitions));
         } catch (ExecutionException _) {
             return Map.of();
         } catch (InterruptedException _) {

--- a/src/test/java/com/michelin/ns4kafka/integration/ConsumerGroupIntegrationTest.java
+++ b/src/test/java/com/michelin/ns4kafka/integration/ConsumerGroupIntegrationTest.java
@@ -38,7 +38,7 @@ import com.michelin.ns4kafka.model.RoleBinding.Subject;
 import com.michelin.ns4kafka.model.RoleBinding.SubjectType;
 import com.michelin.ns4kafka.model.RoleBinding.Verb;
 import com.michelin.ns4kafka.model.consumer.group.ConsumerGroup;
-import com.michelin.ns4kafka.model.consumer.group.ConsumerGroup.ConsumerGroupOffset;
+import com.michelin.ns4kafka.model.consumer.group.ConsumerGroup.ConsumerGroupStatus;
 import com.michelin.ns4kafka.model.consumer.group.ConsumerGroupResetOffsets;
 import com.michelin.ns4kafka.model.consumer.group.ConsumerGroupResetOffsets.ConsumerGroupResetOffsetsSpec;
 import com.michelin.ns4kafka.model.consumer.group.ConsumerGroupResetOffsets.ResetOffsetsMethod;
@@ -229,20 +229,20 @@ class ConsumerGroupIntegrationTest extends KafkaIntegrationTest {
                                 .bearerAuth(token),
                         Argument.listOf(ConsumerGroup.class));
 
-        assertEquals(1, consumerGroups.size());
+        // The consumer group is flattened into one entry per topic-partition
+        assertEquals(6, consumerGroups.size());
         assertTrue(consumerGroups.stream()
-                .anyMatch(consumerGroup ->
+                .allMatch(consumerGroup ->
                         "ns1-consumerGroup".equals(consumerGroup.getMetadata().getName())));
-        assertEquals(GroupState.EMPTY, consumerGroups.getFirst().getStatus().getState());
         assertEquals(
                 List.of(
-                        new ConsumerGroupOffset("ns1-topic", 0, 1, 1, 0),
-                        new ConsumerGroupOffset("ns1-topic", 1, 1, 1, 0),
-                        new ConsumerGroupOffset("ns1-topic", 2, 1, 1, 0),
-                        new ConsumerGroupOffset("other-topic", 0, 1, 1, 0),
-                        new ConsumerGroupOffset("other-topic", 1, 1, 1, 0),
-                        new ConsumerGroupOffset("other-topic", 2, 1, 1, 0)),
-                consumerGroups.getFirst().getStatus().getOffsets());
+                        new ConsumerGroupStatus(GroupState.EMPTY, "ns1-topic", 0, 1L, 1L, 0L),
+                        new ConsumerGroupStatus(GroupState.EMPTY, "ns1-topic", 1, 1L, 1L, 0L),
+                        new ConsumerGroupStatus(GroupState.EMPTY, "ns1-topic", 2, 1L, 1L, 0L),
+                        new ConsumerGroupStatus(GroupState.EMPTY, "other-topic", 0, 1L, 1L, 0L),
+                        new ConsumerGroupStatus(GroupState.EMPTY, "other-topic", 1, 1L, 1L, 0L),
+                        new ConsumerGroupStatus(GroupState.EMPTY, "other-topic", 2, 1L, 1L, 0L)),
+                consumerGroups.stream().map(ConsumerGroup::getStatus).toList());
 
         assertTrue(consumerGroups.stream()
                 .noneMatch(consumerGroup ->
@@ -311,18 +311,16 @@ class ConsumerGroupIntegrationTest extends KafkaIntegrationTest {
         assertTrue(externalConsumerGroups.stream()
                 .anyMatch(consumerGroup -> "externalConsumerGroup"
                         .equals(consumerGroup.getMetadata().getName())));
-        ConsumerGroup externalConsumerGroup = externalConsumerGroups.stream()
+        List<ConsumerGroup> externalConsumerGroup = externalConsumerGroups.stream()
                 .filter(consumerGroup -> "externalConsumerGroup"
                         .equals(consumerGroup.getMetadata().getName()))
-                .findFirst()
-                .orElseThrow();
-        assertEquals(GroupState.EMPTY, externalConsumerGroup.getStatus().getState());
+                .toList();
         assertEquals(
                 List.of(
-                        new ConsumerGroupOffset("ns1-externalTopic", 0, 1, 1, 0),
-                        new ConsumerGroupOffset("ns1-externalTopic", 1, 1, 1, 0),
-                        new ConsumerGroupOffset("ns1-externalTopic", 2, 1, 1, 0)),
-                externalConsumerGroup.getStatus().getOffsets());
+                        new ConsumerGroupStatus(GroupState.EMPTY, "ns1-externalTopic", 0, 1L, 1L, 0L),
+                        new ConsumerGroupStatus(GroupState.EMPTY, "ns1-externalTopic", 1, 1L, 1L, 0L),
+                        new ConsumerGroupStatus(GroupState.EMPTY, "ns1-externalTopic", 2, 1L, 1L, 0L)),
+                externalConsumerGroup.stream().map(ConsumerGroup::getStatus).toList());
 
         assertTrue(externalConsumerGroups.stream()
                 .noneMatch(consumerGroup ->
@@ -367,16 +365,16 @@ class ConsumerGroupIntegrationTest extends KafkaIntegrationTest {
                                 .bearerAuth(token),
                         Argument.listOf(ConsumerGroup.class));
 
-        assertEquals(1, consumerGroups.size());
-        assertEquals(
-                "ns1-resetConsumerGroup",
-                consumerGroups.getFirst().getMetadata().getName());
+        assertEquals(3, consumerGroups.size());
+        assertTrue(consumerGroups.stream()
+                .allMatch(consumerGroup -> "ns1-resetConsumerGroup"
+                        .equals(consumerGroup.getMetadata().getName())));
         assertEquals(
                 List.of(
-                        new ConsumerGroupOffset("ns1-resetTopic", 0, 0, 0, 0),
-                        new ConsumerGroupOffset("ns1-resetTopic", 1, 0, 0, 0),
-                        new ConsumerGroupOffset("ns1-resetTopic", 2, 0, 0, 0)),
-                consumerGroups.getFirst().getStatus().getOffsets());
+                        new ConsumerGroupStatus(GroupState.EMPTY, "ns1-resetTopic", 0, 0L, 0L, 0L),
+                        new ConsumerGroupStatus(GroupState.EMPTY, "ns1-resetTopic", 1, 0L, 0L, 0L),
+                        new ConsumerGroupStatus(GroupState.EMPTY, "ns1-resetTopic", 2, 0L, 0L, 0L)),
+                consumerGroups.stream().map(ConsumerGroup::getStatus).toList());
 
         HttpResponse<Void> deleteResponse = ns4KafkaClient
                 .toBlocking()

--- a/src/test/java/com/michelin/ns4kafka/integration/ConsumerGroupIntegrationTest.java
+++ b/src/test/java/com/michelin/ns4kafka/integration/ConsumerGroupIntegrationTest.java
@@ -236,12 +236,12 @@ class ConsumerGroupIntegrationTest extends KafkaIntegrationTest {
         assertEquals(GroupState.EMPTY, consumerGroups.getFirst().getStatus().getState());
         assertEquals(
                 List.of(
-                        new ConsumerGroupOffset("ns1-topic", 0, 1),
-                        new ConsumerGroupOffset("ns1-topic", 1, 1),
-                        new ConsumerGroupOffset("ns1-topic", 2, 1),
-                        new ConsumerGroupOffset("other-topic", 0, 1),
-                        new ConsumerGroupOffset("other-topic", 1, 1),
-                        new ConsumerGroupOffset("other-topic", 2, 1)),
+                        new ConsumerGroupOffset("ns1-topic", 0, 1, 1, 0),
+                        new ConsumerGroupOffset("ns1-topic", 1, 1, 1, 0),
+                        new ConsumerGroupOffset("ns1-topic", 2, 1, 1, 0),
+                        new ConsumerGroupOffset("other-topic", 0, 1, 1, 0),
+                        new ConsumerGroupOffset("other-topic", 1, 1, 1, 0),
+                        new ConsumerGroupOffset("other-topic", 2, 1, 1, 0)),
                 consumerGroups.getFirst().getStatus().getOffsets());
 
         assertTrue(consumerGroups.stream()
@@ -319,9 +319,9 @@ class ConsumerGroupIntegrationTest extends KafkaIntegrationTest {
         assertEquals(GroupState.EMPTY, externalConsumerGroup.getStatus().getState());
         assertEquals(
                 List.of(
-                        new ConsumerGroupOffset("ns1-externalTopic", 0, 1),
-                        new ConsumerGroupOffset("ns1-externalTopic", 1, 1),
-                        new ConsumerGroupOffset("ns1-externalTopic", 2, 1)),
+                        new ConsumerGroupOffset("ns1-externalTopic", 0, 1, 1, 0),
+                        new ConsumerGroupOffset("ns1-externalTopic", 1, 1, 1, 0),
+                        new ConsumerGroupOffset("ns1-externalTopic", 2, 1, 1, 0)),
                 externalConsumerGroup.getStatus().getOffsets());
 
         assertTrue(externalConsumerGroups.stream()
@@ -373,9 +373,9 @@ class ConsumerGroupIntegrationTest extends KafkaIntegrationTest {
                 consumerGroups.getFirst().getMetadata().getName());
         assertEquals(
                 List.of(
-                        new ConsumerGroupOffset("ns1-resetTopic", 0, 0),
-                        new ConsumerGroupOffset("ns1-resetTopic", 1, 0),
-                        new ConsumerGroupOffset("ns1-resetTopic", 2, 0)),
+                        new ConsumerGroupOffset("ns1-resetTopic", 0, 0, 0, 0),
+                        new ConsumerGroupOffset("ns1-resetTopic", 1, 0, 0, 0),
+                        new ConsumerGroupOffset("ns1-resetTopic", 2, 0, 0, 0)),
                 consumerGroups.getFirst().getStatus().getOffsets());
 
         HttpResponse<Void> deleteResponse = ns4KafkaClient

--- a/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
@@ -19,7 +19,9 @@
 package com.michelin.ns4kafka.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -79,7 +81,8 @@ class ConsumerGroupServiceTest {
         ConsumerGroupDescription stableDescription =
                 new ConsumerGroupDescription(null, true, null, null, null, GroupState.STABLE, null, null, null, null);
 
-        TopicPartition partition = new TopicPartition("namespace-topic", 0);
+        TopicPartition partition0 = new TopicPartition("namespace-topic", 0);
+        TopicPartition partition1 = new TopicPartition("namespace-topic", 1);
 
         when(applicationContext.getBean(
                         ConsumerGroupAsyncExecutor.class,
@@ -92,27 +95,33 @@ class ConsumerGroupServiceTest {
                 .thenReturn(false);
         when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("abc.group1")))
                 .thenReturn(Map.of("abc.group1", stableDescription));
-        when(consumerGroupAsyncExecutor.getCommittedOffsets("abc.group1")).thenReturn(Map.of(partition, 5L));
-        when(consumerGroupAsyncExecutor.getLogEndOffsets(List.of(partition))).thenReturn(Map.of(partition, 12L));
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("abc.group1"))
+                .thenReturn(Map.of(partition0, 5L, partition1, 8L));
+        when(consumerGroupAsyncExecutor.getLogEndOffsets(anyList()))
+                .thenReturn(Map.of(partition0, 12L, partition1, 20L));
 
         List<ConsumerGroup> result = consumerGroupService.findByWildcardName(namespace, "*");
 
-        assertEquals(1, result.size());
+        // The group is flattened into one consumer group per topic-partition
+        assertEquals(2, result.size());
 
         ConsumerGroup firstGroup = result.getFirst();
         assertEquals("abc.group1", firstGroup.getMetadata().getName());
         assertEquals("namespace", firstGroup.getMetadata().getNamespace());
         assertEquals("test", firstGroup.getMetadata().getCluster());
         assertEquals(GroupState.STABLE, firstGroup.getStatus().getState());
-        assertEquals(1, firstGroup.getStatus().getOffsets().size());
+        assertEquals("namespace-topic", firstGroup.getStatus().getTopic());
+        assertEquals(0, firstGroup.getStatus().getPartition());
+        assertEquals(5L, firstGroup.getStatus().getCurrentOffset());
+        assertEquals(12L, firstGroup.getStatus().getLogEndOffset());
+        assertEquals(7L, firstGroup.getStatus().getLag());
 
-        ConsumerGroup.ConsumerGroupOffset offset =
-                firstGroup.getStatus().getOffsets().getFirst();
-        assertEquals("namespace-topic", offset.getTopic());
-        assertEquals(0, offset.getPartition());
-        assertEquals(5L, offset.getCurrentOffset());
-        assertEquals(12L, offset.getLogEndOffset());
-        assertEquals(7L, offset.getLag());
+        ConsumerGroup secondGroup = result.get(1);
+        assertEquals("abc.group1", secondGroup.getMetadata().getName());
+        assertEquals(1, secondGroup.getStatus().getPartition());
+        assertEquals(8L, secondGroup.getStatus().getCurrentOffset());
+        assertEquals(20L, secondGroup.getStatus().getLogEndOffset());
+        assertEquals(12L, secondGroup.getStatus().getLag());
     }
 
     @Test
@@ -148,12 +157,16 @@ class ConsumerGroupServiceTest {
         assertEquals("namespace", firstGroup.getMetadata().getNamespace());
         assertEquals("test", firstGroup.getMetadata().getCluster());
         assertEquals(GroupState.STABLE, firstGroup.getStatus().getState());
-        assertTrue(firstGroup.getStatus().getOffsets().isEmpty());
+        assertNull(firstGroup.getStatus().getTopic());
+        assertNull(firstGroup.getStatus().getPartition());
+        assertNull(firstGroup.getStatus().getCurrentOffset());
+        assertNull(firstGroup.getStatus().getLogEndOffset());
+        assertNull(firstGroup.getStatus().getLag());
 
         ConsumerGroup secondGroup = result.get(1);
         assertEquals("abc.group2", secondGroup.getMetadata().getName());
         assertEquals(GroupState.UNKNOWN, secondGroup.getStatus().getState());
-        assertTrue(secondGroup.getStatus().getOffsets().isEmpty());
+        assertNull(secondGroup.getStatus().getTopic());
         verify(consumerGroupAsyncExecutor, never()).getCommittedOffsets(anyString());
     }
 
@@ -186,13 +199,13 @@ class ConsumerGroupServiceTest {
 
         assertEquals(1, result.size());
         assertEquals("abc.group2", result.getFirst().getMetadata().getName());
-        assertEquals(1, result.getFirst().getStatus().getOffsets().size());
 
-        ConsumerGroup.ConsumerGroupOffset offset =
-                result.getFirst().getStatus().getOffsets().getFirst();
-        assertEquals(3L, offset.getCurrentOffset());
-        assertEquals(10L, offset.getLogEndOffset());
-        assertEquals(7L, offset.getLag());
+        ConsumerGroup group = result.getFirst();
+        assertEquals("topic2", group.getStatus().getTopic());
+        assertEquals(0, group.getStatus().getPartition());
+        assertEquals(3L, group.getStatus().getCurrentOffset());
+        assertEquals(10L, group.getStatus().getLogEndOffset());
+        assertEquals(7L, group.getStatus().getLag());
     }
 
     @Test
@@ -226,11 +239,10 @@ class ConsumerGroupServiceTest {
 
         assertEquals(1, result.size());
 
-        ConsumerGroup.ConsumerGroupOffset offset =
-                result.getFirst().getStatus().getOffsets().getFirst();
-        assertEquals(5L, offset.getCurrentOffset());
-        assertEquals(0L, offset.getLogEndOffset());
-        assertEquals(0L, offset.getLag());
+        ConsumerGroup group = result.getFirst();
+        assertEquals(5L, group.getStatus().getCurrentOffset());
+        assertEquals(0L, group.getStatus().getLogEndOffset());
+        assertEquals(0L, group.getStatus().getLag());
     }
 
     @Test
@@ -264,11 +276,10 @@ class ConsumerGroupServiceTest {
 
         assertEquals(1, result.size());
 
-        ConsumerGroup.ConsumerGroupOffset offset =
-                result.getFirst().getStatus().getOffsets().getFirst();
-        assertEquals(5L, offset.getCurrentOffset());
-        assertEquals(0L, offset.getLogEndOffset());
-        assertEquals(0L, offset.getLag());
+        ConsumerGroup group = result.getFirst();
+        assertEquals(5L, group.getStatus().getCurrentOffset());
+        assertEquals(0L, group.getStatus().getLogEndOffset());
+        assertEquals(0L, group.getStatus().getLag());
         // The interrupt flag is set by the service; clear it so it does not leak to other tests
         assertTrue(Thread.interrupted());
     }
@@ -339,14 +350,12 @@ class ConsumerGroupServiceTest {
 
         assertEquals(1, result.size());
         assertEquals("def.group1", result.getFirst().getMetadata().getName());
-        assertEquals(1, result.getFirst().getStatus().getOffsets().size());
 
-        ConsumerGroup.ConsumerGroupOffset offset =
-                result.getFirst().getStatus().getOffsets().getFirst();
-        assertEquals("abc.namespace-topic", offset.getTopic());
-        assertEquals(5L, offset.getCurrentOffset());
-        assertEquals(8L, offset.getLogEndOffset());
-        assertEquals(3L, offset.getLag());
+        ConsumerGroup group = result.getFirst();
+        assertEquals("abc.namespace-topic", group.getStatus().getTopic());
+        assertEquals(5L, group.getStatus().getCurrentOffset());
+        assertEquals(8L, group.getStatus().getLogEndOffset());
+        assertEquals(3L, group.getStatus().getLag());
     }
 
     @Test

--- a/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
@@ -196,6 +196,84 @@ class ConsumerGroupServiceTest {
     }
 
     @Test
+    void shouldListConsumerGroupsWithoutLogEndOffsets() throws InterruptedException, ExecutionException {
+        Namespace namespace = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("namespace")
+                        .cluster("test")
+                        .build())
+                .build();
+
+        ConsumerGroupDescription stableDescription =
+                new ConsumerGroupDescription(null, true, null, null, null, GroupState.STABLE, null, null, null, null);
+
+        TopicPartition partition = new TopicPartition("namespace-topic", 0);
+
+        when(applicationContext.getBean(
+                        ConsumerGroupAsyncExecutor.class,
+                        Qualifiers.byName(namespace.getMetadata().getCluster())))
+                .thenReturn(consumerGroupAsyncExecutor);
+        when(consumerGroupAsyncExecutor.listConsumerGroupIds()).thenReturn(List.of("abc.group1"));
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "abc.group1"))
+                .thenReturn(true);
+        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("abc.group1")))
+                .thenReturn(Map.of("abc.group1", stableDescription));
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("abc.group1")).thenReturn(Map.of(partition, 5L));
+        when(consumerGroupAsyncExecutor.getLogEndOffsets(List.of(partition)))
+                .thenThrow(new ExecutionException(new RuntimeException("boom")));
+
+        List<ConsumerGroup> result = consumerGroupService.findByWildcardName(namespace, "*");
+
+        assertEquals(1, result.size());
+
+        ConsumerGroup.ConsumerGroupOffset offset =
+                result.getFirst().getStatus().getOffsets().getFirst();
+        assertEquals(5L, offset.getCurrentOffset());
+        assertEquals(0L, offset.getLogEndOffset());
+        assertEquals(0L, offset.getLag());
+    }
+
+    @Test
+    void shouldListConsumerGroupsWithoutLogEndOffsetsWhenInterrupted() throws InterruptedException, ExecutionException {
+        Namespace namespace = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("namespace")
+                        .cluster("test")
+                        .build())
+                .build();
+
+        ConsumerGroupDescription stableDescription =
+                new ConsumerGroupDescription(null, true, null, null, null, GroupState.STABLE, null, null, null, null);
+
+        TopicPartition partition = new TopicPartition("namespace-topic", 0);
+
+        when(applicationContext.getBean(
+                        ConsumerGroupAsyncExecutor.class,
+                        Qualifiers.byName(namespace.getMetadata().getCluster())))
+                .thenReturn(consumerGroupAsyncExecutor);
+        when(consumerGroupAsyncExecutor.listConsumerGroupIds()).thenReturn(List.of("abc.group1"));
+        when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "abc.group1"))
+                .thenReturn(true);
+        when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("abc.group1")))
+                .thenReturn(Map.of("abc.group1", stableDescription));
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("abc.group1")).thenReturn(Map.of(partition, 5L));
+        when(consumerGroupAsyncExecutor.getLogEndOffsets(List.of(partition)))
+                .thenThrow(new InterruptedException("interrupted"));
+
+        List<ConsumerGroup> result = consumerGroupService.findByWildcardName(namespace, "*");
+
+        assertEquals(1, result.size());
+
+        ConsumerGroup.ConsumerGroupOffset offset =
+                result.getFirst().getStatus().getOffsets().getFirst();
+        assertEquals(5L, offset.getCurrentOffset());
+        assertEquals(0L, offset.getLogEndOffset());
+        assertEquals(0L, offset.getLag());
+        // The interrupt flag is set by the service; clear it so it does not leak to other tests
+        assertTrue(Thread.interrupted());
+    }
+
+    @Test
     void shouldListConsumerGroupsWhenEmpty() throws InterruptedException, ExecutionException {
         Namespace namespace = Namespace.builder()
                 .metadata(Resource.Metadata.builder()

--- a/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConsumerGroupServiceTest.java
@@ -93,6 +93,7 @@ class ConsumerGroupServiceTest {
         when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("abc.group1")))
                 .thenReturn(Map.of("abc.group1", stableDescription));
         when(consumerGroupAsyncExecutor.getCommittedOffsets("abc.group1")).thenReturn(Map.of(partition, 5L));
+        when(consumerGroupAsyncExecutor.getLogEndOffsets(List.of(partition))).thenReturn(Map.of(partition, 12L));
 
         List<ConsumerGroup> result = consumerGroupService.findByWildcardName(namespace, "*");
 
@@ -110,6 +111,8 @@ class ConsumerGroupServiceTest {
         assertEquals("namespace-topic", offset.getTopic());
         assertEquals(0, offset.getPartition());
         assertEquals(5L, offset.getCurrentOffset());
+        assertEquals(12L, offset.getLogEndOffset());
+        assertEquals(7L, offset.getLag());
     }
 
     @Test
@@ -173,16 +176,23 @@ class ConsumerGroupServiceTest {
                 .thenReturn(true);
         when(aclService.isNamespaceOwnerOfResource("namespace", AccessControlEntry.ResourceType.GROUP, "abc.group2"))
                 .thenReturn(true);
+        TopicPartition partition = new TopicPartition("topic2", 0);
         when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("abc.group2")))
                 .thenReturn(Map.of());
-        when(consumerGroupAsyncExecutor.getCommittedOffsets("abc.group2"))
-                .thenReturn(Map.of(new TopicPartition("topic2", 0), 3L));
+        when(consumerGroupAsyncExecutor.getCommittedOffsets("abc.group2")).thenReturn(Map.of(partition, 3L));
+        when(consumerGroupAsyncExecutor.getLogEndOffsets(List.of(partition))).thenReturn(Map.of(partition, 10L));
 
         List<ConsumerGroup> result = consumerGroupService.findByWildcardName(namespace, "*group2");
 
         assertEquals(1, result.size());
         assertEquals("abc.group2", result.getFirst().getMetadata().getName());
         assertEquals(1, result.getFirst().getStatus().getOffsets().size());
+
+        ConsumerGroup.ConsumerGroupOffset offset =
+                result.getFirst().getStatus().getOffsets().getFirst();
+        assertEquals(3L, offset.getCurrentOffset());
+        assertEquals(10L, offset.getLogEndOffset());
+        assertEquals(7L, offset.getLag());
     }
 
     @Test
@@ -244,15 +254,21 @@ class ConsumerGroupServiceTest {
                 .thenReturn(false);
         when(consumerGroupAsyncExecutor.describeConsumerGroups(List.of("def.group1")))
                 .thenReturn(Map.of("def.group1", stableDescription));
+        when(consumerGroupAsyncExecutor.getLogEndOffsets(List.of(ownedPartition)))
+                .thenReturn(Map.of(ownedPartition, 8L));
 
         List<ConsumerGroup> result = consumerGroupService.findExternalByWildcardName(namespace, "*");
 
         assertEquals(1, result.size());
         assertEquals("def.group1", result.getFirst().getMetadata().getName());
         assertEquals(1, result.getFirst().getStatus().getOffsets().size());
-        assertEquals(
-                "abc.namespace-topic",
-                result.getFirst().getStatus().getOffsets().getFirst().getTopic());
+
+        ConsumerGroup.ConsumerGroupOffset offset =
+                result.getFirst().getStatus().getOffsets().getFirst();
+        assertEquals("abc.namespace-topic", offset.getTopic());
+        assertEquals(5L, offset.getCurrentOffset());
+        assertEquals(8L, offset.getLogEndOffset());
+        assertEquals(3L, offset.getLag());
     }
 
     @Test


### PR DESCRIPTION
## Context

As a Kafka admin, when listing a consumer group I want to see the **current offset**, **end offset**, and **lag** per partition, so I can easily monitor how far each consumer group is behind on the topics it consumes.

Until now, the consumer group listing only exposed the committed `currentOffset` per partition. It did not return the partition end offset, nor the resulting lag. This enhancement is required on the Ns4Kafka side so that `kafkactl` can display this information when listing consumer groups (see [michelin/kafkactl#360](https://github.com/michelin/kafkactl/issues/360)).

## Proposed solution

Enrich the consumer group listing response with two additional fields per partition:

- `logEndOffset` - the latest (end) offset of the partition
- `lag` - the difference between the end offset and the committed current offset (`logEndOffset - currentOffset`)

The existing behavior is intentionally preserved: offsets are only returned for the owned-group listing when **exactly one** group matches the name filter.

## Implementation

- **Model** - Added `logEndOffset` and `lag` fields to `ConsumerGroup.ConsumerGroupOffset`.
- **Service** - In `ConsumerGroupService`:
  - Added a `getLogEndOffsets` helper that fetches the latest offsets for the committed partitions (returning an empty map when there are no partitions, and gracefully handling execution/interrupt exceptions, consistently with `getCommittedOffsets`).
  - `findByWildcardName` (owned groups) and `findExternalByWildcardName` (external groups) now retrieve the log end offsets for the committed partitions and pass them to `buildConsumerGroup`.
  - `buildConsumerGroup` populates `currentOffset`, `logEndOffset`, and the computed `lag` for each partition.

This reuses the existing `ConsumerGroupAsyncExecutor.getLogEndOffsets` admin call, so no new Kafka client logic was introduced.

## Tests

-  (`ConsumerGroupServiceTest`) - Mocked `getLogEndOffsets` and asserted `logEndOffset` and `lag` for both owned and external consumer group listing.
- (`ConsumerGroupIntegrationTest`) - Updated the expected `ConsumerGroupOffset` values to include the new end offset and lag fields when listing groups.

## Remark

The server-side rule of only returning offsets when a single group is queried is unchanged.
