### PR TITLE
Add Ns4Kafka validation before connector offsets reset

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
@@ -416,7 +416,7 @@ public class ConnectorService {
 
                     if (!"STOPPED".equalsIgnoreCase(currentState)) {
                         return Mono.error(new ResourceValidationException(
-                                connector, invalidConnectorResetOperation(connectorName, "STOPPED", currentState)));
+                                connector, invalidConnectorResetOperation(connectorName, "STOPPED")));
                     }
 
                     return kafkaConnectClient.resetOffsets(kafkaCluster, connectCluster, connectorName);

--- a/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
@@ -21,6 +21,7 @@ package com.michelin.ns4kafka.service;
 import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidConnectorConnectCluster;
 import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidConnectorEmptyConnectorClass;
 import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidConnectorNoPlugin;
+import static com.michelin.ns4kafka.util.FormatErrorUtils.invalidConnectorResetOperation;
 import static com.michelin.ns4kafka.util.config.ConnectorConfig.CONNECTOR_CLASS;
 
 import com.michelin.ns4kafka.model.AccessControlEntry;
@@ -34,6 +35,7 @@ import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsetsRes
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorSpecs;
 import com.michelin.ns4kafka.util.FormatErrorUtils;
 import com.michelin.ns4kafka.util.RegexUtils;
+import com.michelin.ns4kafka.util.exception.ResourceValidationException;
 import com.michelin.ns4kafka.validation.ValidationResult;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpResponse;
@@ -403,9 +405,21 @@ public class ConnectorService {
      * @return An HTTP response
      */
     public Mono<HttpResponse<ConnectorOffsetsResponse>> resetOffsets(Namespace namespace, Connector connector) {
-        return kafkaConnectClient.resetOffsets(
-                namespace.getMetadata().getCluster(),
-                connector.getSpec().getConnectCluster(),
-                connector.getMetadata().getName());
+        String kafkaCluster = namespace.getMetadata().getCluster();
+        String connectCluster = connector.getSpec().getConnectCluster();
+        String connectorName = connector.getMetadata().getName();
+
+        return kafkaConnectClient
+                .status(kafkaCluster, connectCluster, connectorName)
+                .flatMap(status -> {
+                    String currentState = status.connector().getState();
+
+                    if (!"STOPPED".equalsIgnoreCase(currentState)) {
+                        return Mono.error(new ResourceValidationException(
+                                connector, invalidConnectorResetOperation(connectorName, "STOPPED", currentState)));
+                    }
+
+                    return kafkaConnectClient.resetOffsets(kafkaCluster, connectCluster, connectorName);
+                });
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
+++ b/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
@@ -328,6 +328,23 @@ public class FormatErrorUtils {
     }
 
     /**
+     * Invalid reset offsets operation on connector.
+     *
+     * @param connector the connector
+     * @param targetState the target state
+     * @param currentState the current state
+     * @return the error message
+     */
+    public static String invalidConnectorResetOperation(String connector, String targetState, String currentState) {
+        return INVALID_OPERATION.formatted(
+                "reset offset",
+                String.format(
+                        "connector \"%s\" must be in the %s state before offsets can be reset. "
+                                + "Stop the connector first using ns4kafka API or Kafkactl, then retry the reset",
+                        connector, targetState));
+    }
+
+    /**
      * Invalid delete operation on consumer group.
      *
      * @param consumerGroup the consumer group

--- a/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
+++ b/src/main/java/com/michelin/ns4kafka/util/FormatErrorUtils.java
@@ -39,6 +39,7 @@ import lombok.NoArgsConstructor;
 public class FormatErrorUtils {
     private static final String OPERATION_APPLY = "apply";
     private static final String OPERATION_DELETE = "delete";
+    private static final String OPERATION_RESET_OFFSET = "reset offset";
     private static final String FIELD_NAME = "name";
     private static final String FIELD_ALIAS = "alias";
     private static final String INVALID_FIELD = "Invalid value \"%s\" for field \"%s\": %s.";
@@ -320,7 +321,7 @@ public class FormatErrorUtils {
      */
     public static String invalidConsumerGroupOperation(String consumerGroup, String targetState, String currentState) {
         return INVALID_OPERATION.formatted(
-                "reset offset",
+                OPERATION_RESET_OFFSET,
                 String.format(
                         "offsets can only be reset if the consumer group \"%s\" "
                                 + "is %s but the current state is %s. Stop the consumption and wait \"session.timeout.ms\" before retrying",
@@ -332,12 +333,11 @@ public class FormatErrorUtils {
      *
      * @param connector the connector
      * @param targetState the target state
-     * @param currentState the current state
      * @return the error message
      */
-    public static String invalidConnectorResetOperation(String connector, String targetState, String currentState) {
+    public static String invalidConnectorResetOperation(String connector, String targetState) {
         return INVALID_OPERATION.formatted(
-                "reset offset",
+                OPERATION_RESET_OFFSET,
                 String.format(
                         "connector \"%s\" must be in the %s state before offsets can be reset. "
                                 + "Stop the connector first using ns4kafka API or Kafkactl, then retry the reset",
@@ -567,7 +567,7 @@ public class FormatErrorUtils {
      * @return the error message
      */
     public static String invalidNamespaceCannotReadTopic(String topic) {
-        return INVALID_OPERATION.formatted("reset offset", "namespace cannot read topic %s".formatted(topic));
+        return INVALID_OPERATION.formatted(OPERATION_RESET_OFFSET, "namespace cannot read topic %s".formatted(topic));
     }
 
     /**

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,6 +48,7 @@ import com.michelin.ns4kafka.service.client.connect.entities.ConnectorPluginInfo
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorStateInfo;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorStatus;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorType;
+import com.michelin.ns4kafka.util.exception.ResourceValidationException;
 import com.michelin.ns4kafka.validation.ConnectValidator;
 import com.michelin.ns4kafka.validation.ResourceValidator;
 import io.micronaut.http.HttpResponse;
@@ -1388,6 +1390,16 @@ class ConnectorServiceTest {
                         .build())
                 .build();
 
+        when(kafkaConnectClient.status(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName()))
+                .thenReturn(Mono.just(new ConnectorStateInfo(
+                        connector.getMetadata().getName(),
+                        new ConnectorStateInfo.ConnectorState("STOPPED", "worker-1", null),
+                        List.of(),
+                        SOURCE)));
+
         when(kafkaConnectClient.resetOffsets(
                         namespace.getMetadata().getCluster(),
                         connector.getSpec().getConnectCluster(),
@@ -1402,6 +1414,62 @@ class ConnectorServiceTest {
                 .verifyComplete();
 
         verify(kafkaConnectClient)
+                .status(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName());
+
+        verify(kafkaConnectClient)
+                .resetOffsets(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName());
+    }
+
+    @Test
+    void shouldNotResetConnectorOffsetsWhenConnectorIsNotStopped() {
+        Namespace namespace = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("namespace")
+                        .cluster("local")
+                        .build())
+                .build();
+
+        Connector connector = Connector.builder()
+                .metadata(Resource.Metadata.builder().name("ns-connect1").build())
+                .spec(Connector.ConnectorSpec.builder()
+                        .connectCluster("local-name")
+                        .build())
+                .build();
+
+        when(kafkaConnectClient.status(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName()))
+                .thenReturn(Mono.just(new ConnectorStateInfo(
+                        connector.getMetadata().getName(),
+                        new ConnectorStateInfo.ConnectorState("RUNNING", "worker-1", null),
+                        List.of(),
+                        SOURCE)));
+
+        StepVerifier.create(connectorService.resetOffsets(namespace, connector))
+                .consumeErrorWith(error -> {
+                    assertEquals(ResourceValidationException.class, error.getClass());
+                    assertEquals(
+                            "Invalid \"reset offset\" operation: connector \"ns-connect1\" must be in the STOPPED state before offsets can be reset. Stop the connector first using ns4kafka API or Kafkactl, then retry the reset.",
+                            ((ResourceValidationException) error)
+                                    .getValidationErrors()
+                                    .getFirst());
+                })
+                .verify();
+
+        verify(kafkaConnectClient)
+                .status(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName());
+
+        verify(kafkaConnectClient, never())
                 .resetOffsets(
                         namespace.getMetadata().getCluster(),
                         connector.getSpec().getConnectCluster(),


### PR DESCRIPTION
## Context

This PR adds the follow-up validation that was discussed during the review of https://github.com/michelin/ns4kafka/pull/821.

Today, when a user tries to reset offsets for a connector that is not stopped, Ns4Kafka delegates the call to Kafka Connect and surfaces the downstream failure. In practice, that ends up returning a Kafka Connect error instead of an Ns4Kafka-owned validation message.

## Proposed solution

Add an explicit validation in Ns4Kafka before sending the reset request to Kafka Connect.

If the connector is not in the `STOPPED` state, Ns4Kafka now fails earlier with its own `ResourceValidationException` and a dedicated message that tells the user to stop the connector first before retrying the reset.

## Implementation

I kept the change intentionally small and aligned with the existing code structure introduced by https://github.com/michelin/ns4kafka/pull/821.

The implementation adds a connector status check in the reset-offsets service path before calling Kafka Connect reset.

On the service side, the reset flow now:

- queries the current connector status from Kafka Connect
- validates that the connector is in the `STOPPED` state
- throws a `ResourceValidationException` with an Ns4Kafka-specific message when the connector is not stopped
- delegates to Kafka Connect reset only when the validation succeeds

## Tests

The test scope covers:

- successful connector offsets reset when the connector is already `STOPPED`
- validation failure when the connector is not stopped
- verification that Kafka Connect reset is not called when the precondition is not met

## Remark

This PR is specifically meant to cater the remaining review requirement from https://github.com/michelin/ns4kafka/pull/821.