### PR TITLE
Enhancement for missing source mapping connector offset list feature

### DIFF
--- a/src/main/java/com/michelin/ns4kafka/model/connect/ConnectorOffsetResponse.java
+++ b/src/main/java/com/michelin/ns4kafka/model/connect/ConnectorOffsetResponse.java
@@ -24,6 +24,7 @@ import com.michelin.ns4kafka.model.Resource;
 import io.micronaut.serde.annotation.Serdeable;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -62,5 +63,7 @@ public class ConnectorOffsetResponse extends Resource {
         private String topic;
         private Integer partition;
         private Long offset;
+        private Map<String, Object> sourcePartition;
+        private Map<String, Object> sourceOffset;
     }
 }

--- a/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
@@ -30,6 +30,7 @@ import com.michelin.ns4kafka.model.connect.Connector;
 import com.michelin.ns4kafka.model.connect.ConnectorOffsetResponse;
 import com.michelin.ns4kafka.repository.ConnectorRepository;
 import com.michelin.ns4kafka.service.client.connect.KafkaConnectClient;
+import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsets;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorOffsetsResponse;
 import com.michelin.ns4kafka.service.client.connect.entities.ConnectorSpecs;
 import com.michelin.ns4kafka.util.FormatErrorUtils;
@@ -291,33 +292,28 @@ public class ConnectorService {
                         connector.getSpec().getConnectCluster(),
                         connector.getMetadata().getName())
                 .map(connectorOffsets -> connectorOffsets.offsets().stream()
-                        .map(connectorOffset -> {
-                            boolean sinkOffset = connectorOffset.partition().containsKey("kafka_topic")
-                                    && connectorOffset.partition().containsKey("kafka_partition");
-                            Object offset = connectorOffset.offset() == null
-                                    ? null
-                                    : connectorOffset.offset().get("kafka_offset");
-                            return ConnectorOffsetResponse.builder()
-                                    .spec(ConnectorOffsetResponse.ConnectorOffsetResponseSpec.builder()
-                                            .topic(
-                                                    sinkOffset
-                                                            ? (String) connectorOffset
-                                                                    .partition()
-                                                                    .get("kafka_topic")
-                                                            : null)
-                                            .partition(
-                                                    sinkOffset
-                                                            ? (Integer) connectorOffset
-                                                                    .partition()
-                                                                    .get("kafka_partition")
-                                                            : null)
-                                            .offset(sinkOffset && offset != null ? ((Number) offset).longValue() : null)
-                                            .sourcePartition(sinkOffset ? null : connectorOffset.partition())
-                                            .sourceOffset(sinkOffset ? null : connectorOffset.offset())
-                                            .build())
-                                    .build();
-                        })
+                        .map(this::toConnectorOffsetResponse)
                         .toList());
+    }
+
+    private ConnectorOffsetResponse toConnectorOffsetResponse(ConnectorOffsets.ConnectorOffset connectorOffset) {
+        boolean sinkOffset = connectorOffset.partition().containsKey("kafka_topic")
+                && connectorOffset.partition().containsKey("kafka_partition");
+        Object offset = connectorOffset.offset() == null
+                ? null
+                : connectorOffset.offset().get("kafka_offset");
+        return ConnectorOffsetResponse.builder()
+                .spec(ConnectorOffsetResponse.ConnectorOffsetResponseSpec.builder()
+                        .topic(sinkOffset ? (String) connectorOffset.partition().get("kafka_topic") : null)
+                        .partition(
+                                sinkOffset
+                                        ? (Integer) connectorOffset.partition().get("kafka_partition")
+                                        : null)
+                        .offset(sinkOffset && offset != null ? ((Number) offset).longValue() : null)
+                        .sourcePartition(sinkOffset ? null : connectorOffset.partition())
+                        .sourceOffset(sinkOffset ? null : connectorOffset.offset())
+                        .build())
+                .build();
     }
 
     /**

--- a/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
+++ b/src/main/java/com/michelin/ns4kafka/service/ConnectorService.java
@@ -292,16 +292,28 @@ public class ConnectorService {
                         connector.getMetadata().getName())
                 .map(connectorOffsets -> connectorOffsets.offsets().stream()
                         .map(connectorOffset -> {
+                            boolean sinkOffset = connectorOffset.partition().containsKey("kafka_topic")
+                                    && connectorOffset.partition().containsKey("kafka_partition");
                             Object offset = connectorOffset.offset() == null
                                     ? null
                                     : connectorOffset.offset().get("kafka_offset");
                             return ConnectorOffsetResponse.builder()
                                     .spec(ConnectorOffsetResponse.ConnectorOffsetResponseSpec.builder()
-                                            .topic((String)
-                                                    connectorOffset.partition().get("kafka_topic"))
-                                            .partition((Integer)
-                                                    connectorOffset.partition().get("kafka_partition"))
-                                            .offset(offset == null ? null : ((Number) offset).longValue())
+                                            .topic(
+                                                    sinkOffset
+                                                            ? (String) connectorOffset
+                                                                    .partition()
+                                                                    .get("kafka_topic")
+                                                            : null)
+                                            .partition(
+                                                    sinkOffset
+                                                            ? (Integer) connectorOffset
+                                                                    .partition()
+                                                                    .get("kafka_partition")
+                                                            : null)
+                                            .offset(sinkOffset && offset != null ? ((Number) offset).longValue() : null)
+                                            .sourcePartition(sinkOffset ? null : connectorOffset.partition())
+                                            .sourceOffset(sinkOffset ? null : connectorOffset.offset())
                                             .build())
                                     .build();
                         })

--- a/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
+++ b/src/test/java/com/michelin/ns4kafka/service/ConnectorServiceTest.java
@@ -1340,6 +1340,42 @@ class ConnectorServiceTest {
     }
 
     @Test
+    void shouldListSourceConnectorOffsets() {
+        Namespace namespace = Namespace.builder()
+                .metadata(Resource.Metadata.builder()
+                        .name("namespace")
+                        .cluster("local")
+                        .build())
+                .build();
+
+        Connector connector = Connector.builder()
+                .metadata(Resource.Metadata.builder().name("ns-connect1").build())
+                .spec(Connector.ConnectorSpec.builder()
+                        .connectCluster("local-name")
+                        .build())
+                .build();
+
+        Map<String, Object> sourcePartition = Map.of("filename", "input.json");
+        Map<String, Object> sourceOffset = Map.of("position", 42L);
+        ConnectorOffsets connectorOffsets =
+                new ConnectorOffsets(List.of(new ConnectorOffsets.ConnectorOffset(sourcePartition, sourceOffset)));
+
+        when(kafkaConnectClient.listOffsets(
+                        namespace.getMetadata().getCluster(),
+                        connector.getSpec().getConnectCluster(),
+                        connector.getMetadata().getName()))
+                .thenReturn(Mono.just(connectorOffsets));
+
+        StepVerifier.create(connectorService.listOffsets(namespace, connector))
+                .consumeNextWith(offsets -> {
+                    assertEquals(1, offsets.size());
+                    assertEquals(sourcePartition, offsets.getFirst().getSpec().getSourcePartition());
+                    assertEquals(sourceOffset, offsets.getFirst().getSpec().getSourceOffset());
+                })
+                .verifyComplete();
+    }
+
+    @Test
     void shouldStopConnector() {
         Namespace namespace = Namespace.builder()
                 .metadata(Resource.Metadata.builder()


### PR DESCRIPTION
## Context

[PR #830](https://github.com/michelin/ns4kafka/pull/830) added support for listing Kafka Connect connector offsets.

The response mapping introduced there handled sink connector offsets only. Sink connectors expose the standard Kafka fields `kafka_topic`, `kafka_partition`, and `kafka_offset`, while source connectors return connector-defined partition and offset data. As a result, source connector offset information was not exposed by Ns4Kafka.

## Proposed solution

Extend the connector offset response so source connector partition and offset data can be returned without assuming a connector-specific schema.

The existing sink connector response fields remain unchanged to preserve the current API behavior.

## Implementation

Added `sourcePartition` and `sourceOffset` map fields to `ConnectorOffsetResponseSpec`.

Updated `ConnectorService.listOffsets` to distinguish standard sink offsets by the presence of `kafka_topic` and `kafka_partition`:

- Sink connector offsets continue to populate `topic`, `partition`, and `offset`.
- Source connector offsets preserve the Kafka Connect `partition` and `offset` maps in `sourcePartition` and `sourceOffset`.

This keeps source offset payloads flexible because their fields are defined by each source connector.

## Tests

Added service coverage for a source connector offset, The test verifies that the partition and offset maps are returned unchanged. Existing sink connector offset coverage remains in place.

## Remark

This is a focused follow-up to [PR #830](https://github.com/michelin/ns4kafka/pull/830). It changes only the response mapping layer; the controller endpoint, ownership checks, and Kafka Connect client call are unchanged.
